### PR TITLE
Decompose inline data access into services + query hooks

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,7 +52,9 @@
       "Bash(python3 -c \"import json,sys; items=json.load\\(sys.stdin\\)['items']; [print\\(f\\\\\"#{i['content']['number']} {i['content']['title']}\\\\\"\\) for i in items if i.get\\('content'\\)]\")",
       "Bash(node:*)",
       "Bash(supabase projects:*)",
-      "Bash(supabase migration:*)"
+      "Bash(supabase migration:*)",
+      "Bash(pnpm --filter @mix/mobile type-check)",
+      "Bash(awk NR>=765 && NR<=800 *)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,155 @@
+# mix — Architecture Guide
+
+This document defines the architectural pattern introduced in the
+`decompose-services` refactor. Every new feature should extend this pattern,
+not work around it.
+
+---
+
+## The core idea
+
+**The DB is the API boundary.** Services are thin, typed wrappers over that
+boundary. Query hooks are a React-specific ergonomic layer over services.
+Screens compose hooks and mutations — they do not contain business logic,
+validation rules, or orchestration logic.
+
+If the UI disappeared tomorrow, every user-facing action must still be
+callable as a plain function. That is the contract.
+
+---
+
+## The layers
+
+```
+apps/mobile/src/
+  services/     <- pure async functions. No React, no hooks.
+  queries/      <- thin TanStack Query wrappers over services.
+  screens/      <- dumb. Call hooks, render JSX, call mutations.
+  lib/          <- platform glue (supabase client, Spotify OAuth helpers).
+  context/      <- stateful orchestration (Session, League, Playback).
+```
+
+### services/
+
+- Pure async functions. No React, no hooks, no framework.
+- Framework-agnostic so any client (prototype screen, alt UI, CLI script)
+  can call them directly.
+- Talk to Supabase (tables or RPCs) and return typed domain objects.
+- Throw typed errors (subclasses of `MixError` in `services/errors.ts`).
+  Never surface raw Postgres messages to callers.
+- One file per domain: `votes.ts`, `submissions.ts`, `rounds.ts`,
+  `seasons.ts`, `leagues.ts`, `results.ts`, `standings.ts`,
+  `commissioner.ts`, `invites.ts`, `auth.ts`, `users.ts`,
+  `spotifySearch.ts`.
+
+### queries/
+
+- One hook per service function that needs caching or reactive data.
+- Keys defined in one place: `queries/keys.ts`. Hierarchical for prefix
+  invalidation (e.g. `['round', roundId]` invalidates every round-scoped
+  entry).
+- Mutation hooks wrap service functions and trigger invalidation via
+  `queries/invalidation.ts`. That file is the single source of truth for
+  what a mutation invalidates.
+- Hooks are thin. If the underlying service changes shape, the hook file
+  should rarely need edits.
+
+### screens/
+
+- Compose hooks. Render JSX. Dispatch mutations on user events.
+- No inline `supabase.from(...)` or `supabase.rpc(...)` calls.
+- No business-logic branching that could live in the service.
+- Client-side helpers that work on already-fetched data (e.g. formatting,
+  phase derivation from timestamps) are fine inline — or extracted to
+  `src/lib/utils/` if reused. These are conceptually distinct from
+  services: services are load-bearing and DB-touching; helpers are
+  cosmetic and pure.
+
+---
+
+## Rules for adding a new feature
+
+When the work touches data or side-effects, follow this order:
+
+1. **Add or update the DB contract first.** New tables, columns, triggers,
+   or RPCs go in `supabase/migrations/` as a timestamped migration.
+   Validation rules that must be enforced belong in the DB — never
+   client-only.
+2. **Add a service function** in the appropriate `services/*.ts` file.
+   Accept camelCase args, return typed domain objects, throw typed errors.
+   If the DB raises a new error message, extend `MixError` subclasses and
+   the `postgresToMixError` mapper.
+3. **Add a query key** entry in `queries/keys.ts`. Put it under the right
+   prefix so invalidation cascades correctly.
+4. **Add a hook** (`use*.ts`) — a thin wrapper over the service.
+   For mutations, add an entry to `invalidations` in
+   `queries/invalidation.ts` and call it from the hook's `onSuccess`.
+5. **Wire the screen** to use the hook. Replace any inline supabase call
+   at the same time. Screens should not gain new inline data access.
+6. **Type-check** (`pnpm --filter @mix/mobile type-check`) and smoke-test
+   the flow before committing.
+
+For strictly cosmetic helpers (formatting, UI state shape), skip steps 1–4
+and keep the helper near the consuming UI.
+
+---
+
+## Canonical examples to imitate
+
+Read these before writing new code in the same shape.
+
+- **Service:** `apps/mobile/src/services/votes.ts`
+- **Typed errors + mapper:** `apps/mobile/src/services/errors.ts`
+- **Query key factory:** `apps/mobile/src/queries/keys.ts`
+- **Invalidation map:** `apps/mobile/src/queries/invalidation.ts`
+- **Query hook:** `apps/mobile/src/queries/useRound.ts`
+- **Mutation hook:** `apps/mobile/src/queries/useSubmitVotes.ts`
+- **Screen wired end-to-end:** `apps/mobile/src/screens/round/RoundScreen.tsx`
+
+---
+
+## Anti-patterns to avoid
+
+Do not:
+
+- Call `supabase.from(...)` or `supabase.rpc(...)` from a screen. Add a
+  service function instead.
+- Use `useState` + `useEffect` to manage server data. Use a query hook.
+- Duplicate validation in the client "just in case." The DB is authoritative;
+  the client catches typed errors from the service.
+- Match on raw Postgres error strings. Add an error class and a mapper entry.
+- Invalidate queries from a screen ad-hoc. Add an entry to the invalidation
+  map and call it from the mutation hook.
+- Introduce a second query key for the same resource. If two callers need the
+  same data, they use the same hook and key.
+- Reach into `lib/` from a screen for anything data-shaped. `lib/` is
+  platform glue consumed by services.
+
+---
+
+## Intentionally out of scope of this pattern
+
+These remain stateful / platform-specific infrastructure and are not
+expected to be services:
+
+- `context/SessionContext.tsx` — Spotify native SDK bridge, AppState
+  foregrounding, Supabase auth orchestration.
+- `context/LeagueContext.tsx` — client state for the active league.
+- `playback/*` — Spotify Web Playback SDK, SoundCloud iframe player, and
+  their React coordinator. Playback is event-driven and reactive; a
+  command-style service API doesn't fit.
+
+If a future need emerges (real-time subscriptions, draft persistence,
+multi-platform auth) that crosses these boundaries, extend the pattern
+deliberately rather than folding everything into services.
+
+---
+
+## Known tech debt tracked against the pattern
+
+- `packages/db/types.ts` is stale; some services cast through `unknown`.
+  Regenerate with `supabase gen types` to clean these up.
+- Per-track vote cap is enforced only in UI. Needs a DB constraint or
+  check in `submit_votes`.
+- `SessionContext` and `LeagueContext` still have inline supabase reads.
+  Intentionally left; migrate if these contexts are ever restructured.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-community/datetimepicker": "^9.1.0",
     "@supabase/supabase-js": "^2.49.4",
+    "@tanstack/react-query": "^5.99.2",
     "@wwdrew/expo-spotify-sdk": "^0.5.0",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",

--- a/apps/mobile/src/app/(tabs)/(home)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/(home)/_layout.tsx
@@ -11,7 +11,6 @@ export default function HomeStackLayout() {
         headerTitleStyle: { fontWeight: '700' },
         headerShadowVisible: false,
         contentStyle: { backgroundColor: '#000' },
-        cardStyle: { backgroundColor: '#000' },
         animation: 'default',
         gestureEnabled: true,
       }}

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Stack, useRouter, useSegments } from "expo-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SessionProvider, useSession } from "@/context/SessionContext";
 import { LeagueProvider } from "@/context/LeagueContext";
 import { SpotifyPlayerProvider, useSpotifyPlayer } from "@/playback/SpotifyWebPlayer";
@@ -38,24 +39,28 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 }
 
 export default function RootLayout() {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
-    <SessionProvider>
-      <SpotifyPlayerProvider>
-        <SoundCloudPlayerProvider>
-        <PlaybackProvider>
-        <LeagueProvider>
-        <AuthGate>
-          <Stack screenOptions={{ headerShown: false, animation: "fade" }}>
-            <Stack.Screen name="(auth)/index" />
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="auth/callback" />
-            <Stack.Screen name="join/index" />
-          </Stack>
-        </AuthGate>
-        </LeagueProvider>
-        </PlaybackProvider>
-        </SoundCloudPlayerProvider>
-      </SpotifyPlayerProvider>
-    </SessionProvider>
+    <QueryClientProvider client={queryClient}>
+      <SessionProvider>
+        <SpotifyPlayerProvider>
+          <SoundCloudPlayerProvider>
+          <PlaybackProvider>
+          <LeagueProvider>
+          <AuthGate>
+            <Stack screenOptions={{ headerShown: false, animation: "fade" }}>
+              <Stack.Screen name="(auth)/index" />
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="auth/callback" />
+              <Stack.Screen name="join/index" />
+            </Stack>
+          </AuthGate>
+          </LeagueProvider>
+          </PlaybackProvider>
+          </SoundCloudPlayerProvider>
+        </SpotifyPlayerProvider>
+      </SessionProvider>
+    </QueryClientProvider>
   );
 }

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -31,7 +31,7 @@ function AuthGate({ children }: { children: React.ReactNode }) {
     if (!session && !inAuthGroup && !inAuthCallback) {
       router.replace("/(auth)");
     } else if (session && inAuthGroup) {
-      router.replace("/(tabs)");
+      router.replace("/(tabs)/(home)");
     }
   }, [session, loading, segments, router]);
 

--- a/apps/mobile/src/queries/invalidation.ts
+++ b/apps/mobile/src/queries/invalidation.ts
@@ -13,4 +13,28 @@ export const invalidations = {
     // A submit may auto-close the round, so refresh everything round-scoped.
     qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
   },
+  updateSeason: (qc: QueryClient, ctx: { seasonId: string }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
+  },
+  updateRound: (
+    qc: QueryClient,
+    ctx: { roundId: string; seasonId?: string },
+  ) => {
+    qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
+    if (ctx.seasonId) {
+      qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
+    }
+  },
+  createRound: (qc: QueryClient, ctx: { seasonId: string }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
+  },
+  forceEndRound: (
+    qc: QueryClient,
+    ctx: { roundId: string; seasonId?: string },
+  ) => {
+    qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
+    if (ctx.seasonId) {
+      qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
+    }
+  },
 };

--- a/apps/mobile/src/queries/invalidation.ts
+++ b/apps/mobile/src/queries/invalidation.ts
@@ -1,0 +1,12 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./keys";
+
+// Mutation → cache effects. Edit this file when a UI surface needs different
+// cache behavior. Hooks import from here so all invalidation logic lives in
+// one place.
+
+export const invalidations = {
+  submitVotes: (qc: QueryClient, ctx: { roundId: string }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
+  },
+};

--- a/apps/mobile/src/queries/invalidation.ts
+++ b/apps/mobile/src/queries/invalidation.ts
@@ -9,4 +9,8 @@ export const invalidations = {
   submitVotes: (qc: QueryClient, ctx: { roundId: string }) => {
     qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
   },
+  submitRoundEntries: (qc: QueryClient, ctx: { roundId: string }) => {
+    // A submit may auto-close the round, so refresh everything round-scoped.
+    qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) });
+  },
 };

--- a/apps/mobile/src/queries/invalidation.ts
+++ b/apps/mobile/src/queries/invalidation.ts
@@ -37,4 +37,25 @@ export const invalidations = {
       qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
     }
   },
+  createLeague: (qc: QueryClient, ctx: { userId?: string }) => {
+    if (ctx.userId) {
+      qc.invalidateQueries({ queryKey: queryKeys.userFirstLeague(ctx.userId) });
+    }
+  },
+  createSeason: (qc: QueryClient, ctx: { leagueId: string }) => {
+    qc.invalidateQueries({ queryKey: queryKeys.leagueSeasons(ctx.leagueId) });
+    qc.invalidateQueries({
+      queryKey: queryKeys.leagueActiveSeason(ctx.leagueId),
+    });
+  },
+  joinLeague: (
+    qc: QueryClient,
+    ctx: { leagueId: string; userId: string },
+  ) => {
+    qc.invalidateQueries({ queryKey: queryKeys.leagueMembers(ctx.leagueId) });
+    qc.invalidateQueries({
+      queryKey: queryKeys.myRole(ctx.leagueId, ctx.userId),
+    });
+    qc.invalidateQueries({ queryKey: queryKeys.userFirstLeague(ctx.userId) });
+  },
 };

--- a/apps/mobile/src/queries/keys.ts
+++ b/apps/mobile/src/queries/keys.ts
@@ -12,6 +12,8 @@ export const queryKeys = {
     ["round", roundId, "myVotes", userId] as const,
   previousRound: (seasonId: string, roundNumber: number) =>
     ["season", seasonId, "prevRound", roundNumber] as const,
+  roundResults: (roundId: string) => ["round", roundId, "results"] as const,
+  roundVoters: (roundId: string) => ["round", roundId, "voters"] as const,
 
   // Season
   season: (seasonId: string) => ["season", seasonId] as const,
@@ -19,6 +21,10 @@ export const queryKeys = {
   seasonRounds: (seasonId: string) => ["season", seasonId, "rounds"] as const,
   seasonRoundCount: (seasonId: string) =>
     ["season", seasonId, "roundCount"] as const,
+  seasonStandings: (seasonId: string) =>
+    ["season", seasonId, "standings"] as const,
+  seasonAggregates: (seasonId: string) =>
+    ["season", seasonId, "aggregates"] as const,
 
   // League
   league: (leagueId: string) => ["league", leagueId] as const,

--- a/apps/mobile/src/queries/keys.ts
+++ b/apps/mobile/src/queries/keys.ts
@@ -1,0 +1,11 @@
+// Single source of truth for TanStack Query keys. Hierarchical so prefix
+// invalidation (e.g. ['round', roundId]) nukes every round-scoped entry in
+// one call.
+
+export const queryKeys = {
+  round: (roundId: string) => ["round", roundId] as const,
+  roundSubmissions: (roundId: string) =>
+    ["round", roundId, "submissions"] as const,
+  myVotes: (roundId: string, userId: string) =>
+    ["round", roundId, "myVotes", userId] as const,
+};

--- a/apps/mobile/src/queries/keys.ts
+++ b/apps/mobile/src/queries/keys.ts
@@ -3,9 +3,36 @@
 // one call.
 
 export const queryKeys = {
+  // Round
   round: (roundId: string) => ["round", roundId] as const,
+  roundDetail: (roundId: string) => ["round", roundId, "detail"] as const,
   roundSubmissions: (roundId: string) =>
     ["round", roundId, "submissions"] as const,
   myVotes: (roundId: string, userId: string) =>
     ["round", roundId, "myVotes", userId] as const,
+  previousRound: (seasonId: string, roundNumber: number) =>
+    ["season", seasonId, "prevRound", roundNumber] as const,
+
+  // Season
+  season: (seasonId: string) => ["season", seasonId] as const,
+  seasonDetail: (seasonId: string) => ["season", seasonId, "detail"] as const,
+  seasonRounds: (seasonId: string) => ["season", seasonId, "rounds"] as const,
+  seasonRoundCount: (seasonId: string) =>
+    ["season", seasonId, "roundCount"] as const,
+
+  // League
+  league: (leagueId: string) => ["league", leagueId] as const,
+  leagueDetail: (leagueId: string) => ["league", leagueId, "detail"] as const,
+  leagueSeasons: (leagueId: string) =>
+    ["league", leagueId, "seasons"] as const,
+  leagueMembers: (leagueId: string) =>
+    ["league", leagueId, "members"] as const,
+  leagueActiveSeason: (leagueId: string) =>
+    ["league", leagueId, "activeSeason"] as const,
+  myRole: (leagueId: string, userId: string) =>
+    ["league", leagueId, "role", userId] as const,
+
+  // User
+  userFirstLeague: (userId: string) =>
+    ["user", userId, "firstLeague"] as const,
 };

--- a/apps/mobile/src/queries/useActiveRoundForLeague.ts
+++ b/apps/mobile/src/queries/useActiveRoundForLeague.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getActiveRoundForLeague } from "@/services/rounds";
+
+export function useActiveRoundForLeague(leagueId: string | undefined) {
+  return useQuery({
+    queryKey: ["league", leagueId ?? "", "activeRound"] as const,
+    queryFn: () => getActiveRoundForLeague(leagueId!),
+    enabled: !!leagueId,
+  });
+}

--- a/apps/mobile/src/queries/useActiveSeasonForLeague.ts
+++ b/apps/mobile/src/queries/useActiveSeasonForLeague.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getActiveSeasonForLeague } from "@/services/seasons";
+import { queryKeys } from "./keys";
+
+export function useActiveSeasonForLeague(leagueId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.leagueActiveSeason(leagueId ?? ""),
+    queryFn: () => getActiveSeasonForLeague(leagueId!),
+    enabled: !!leagueId,
+  });
+}

--- a/apps/mobile/src/queries/useCreateLeague.ts
+++ b/apps/mobile/src/queries/useCreateLeague.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createLeague, type CreateLeagueArgs } from "@/services/leagues";
+import { invalidations } from "./invalidation";
+
+export function useCreateLeague() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: CreateLeagueArgs & { userId?: string }) =>
+      createLeague(args),
+    onSuccess: (_data, variables) => {
+      invalidations.createLeague(qc, { userId: variables.userId });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useCreateRound.ts
+++ b/apps/mobile/src/queries/useCreateRound.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createRound, type CreateRoundArgs } from "@/services/commissioner";
+import { invalidations } from "./invalidation";
+
+export function useCreateRound() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: CreateRoundArgs) => createRound(args),
+    onSuccess: (_data, variables) => {
+      invalidations.createRound(qc, { seasonId: variables.seasonId });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useCreateSeason.ts
+++ b/apps/mobile/src/queries/useCreateSeason.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createSeason, type CreateSeasonArgs } from "@/services/seasons";
+import { invalidations } from "./invalidation";
+
+export function useCreateSeason() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: CreateSeasonArgs) => createSeason(args),
+    onSuccess: (_data, variables) => {
+      invalidations.createSeason(qc, { leagueId: variables.leagueId });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useForceEndRound.ts
+++ b/apps/mobile/src/queries/useForceEndRound.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { forceEndRound } from "@/services/commissioner";
+import { invalidations } from "./invalidation";
+
+export function useForceEndRound() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { roundId: string; seasonId?: string }) =>
+      forceEndRound(args.roundId),
+    onSuccess: (_data, variables) => {
+      invalidations.forceEndRound(qc, {
+        roundId: variables.roundId,
+        seasonId: variables.seasonId,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useIsLeagueMember.ts
+++ b/apps/mobile/src/queries/useIsLeagueMember.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { isLeagueMember } from "@/services/leagues";
+
+export function useIsLeagueMember(
+  leagueId: string | undefined,
+  userId: string | undefined,
+) {
+  return useQuery({
+    queryKey: ["league", leagueId ?? "", "isMember", userId ?? ""] as const,
+    queryFn: () => isLeagueMember(leagueId!, userId!),
+    enabled: !!leagueId && !!userId,
+  });
+}

--- a/apps/mobile/src/queries/useJoinInviteInfo.ts
+++ b/apps/mobile/src/queries/useJoinInviteInfo.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getJoinInviteInfo } from "@/services/invites";
+
+export function useJoinInviteInfo(token: string | undefined) {
+  return useQuery({
+    queryKey: ["joinInvite", token ?? ""],
+    queryFn: () => getJoinInviteInfo(token!),
+    enabled: !!token,
+  });
+}

--- a/apps/mobile/src/queries/useJoinLeague.ts
+++ b/apps/mobile/src/queries/useJoinLeague.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { joinLeagueViaInvite } from "@/services/invites";
+import { invalidations } from "./invalidation";
+
+export function useJoinLeague() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      leagueId: string;
+      userId: string;
+      role: "participant" | "spectator";
+    }) => joinLeagueViaInvite(args),
+    onSuccess: (_data, variables) => {
+      invalidations.joinLeague(qc, {
+        leagueId: variables.leagueId,
+        userId: variables.userId,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useLeague.ts
+++ b/apps/mobile/src/queries/useLeague.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLeague } from "@/services/leagues";
+import { queryKeys } from "./keys";
+
+export function useLeague(leagueId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.leagueDetail(leagueId ?? ""),
+    queryFn: () => getLeague(leagueId!),
+    enabled: !!leagueId,
+  });
+}

--- a/apps/mobile/src/queries/useLeagueMembers.ts
+++ b/apps/mobile/src/queries/useLeagueMembers.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLeagueMembers } from "@/services/leagues";
+import { queryKeys } from "./keys";
+
+export function useLeagueMembers(leagueId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.leagueMembers(leagueId ?? ""),
+    queryFn: () => getLeagueMembers(leagueId!),
+    enabled: !!leagueId,
+  });
+}

--- a/apps/mobile/src/queries/useMyLeagues.ts
+++ b/apps/mobile/src/queries/useMyLeagues.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyLeagues } from "@/services/users";
+
+export function useMyLeagues(userId: string | undefined) {
+  return useQuery({
+    queryKey: ["user", userId ?? "", "leagues"] as const,
+    queryFn: () => getMyLeagues(),
+    enabled: !!userId,
+  });
+}

--- a/apps/mobile/src/queries/useMyRole.ts
+++ b/apps/mobile/src/queries/useMyRole.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyRole } from "@/services/leagues";
+import { queryKeys } from "./keys";
+
+export function useMyRole(
+  leagueId: string | undefined,
+  userId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.myRole(leagueId ?? "", userId ?? ""),
+    queryFn: () => getMyRole(leagueId!, userId!),
+    enabled: !!leagueId && !!userId,
+  });
+}

--- a/apps/mobile/src/queries/useMyVotes.ts
+++ b/apps/mobile/src/queries/useMyVotes.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getMyVotes } from "@/services/votes";
+import { queryKeys } from "./keys";
+
+export function useMyVotes(
+  roundId: string | undefined,
+  userId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.myVotes(roundId ?? "", userId ?? ""),
+    queryFn: () => getMyVotes(roundId!, userId!),
+    enabled: !!roundId && !!userId,
+  });
+}

--- a/apps/mobile/src/queries/usePreviousRound.ts
+++ b/apps/mobile/src/queries/usePreviousRound.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPreviousRound } from "@/services/rounds";
+import { queryKeys } from "./keys";
+
+export function usePreviousRound(
+  seasonId: string | undefined,
+  currentRoundNumber: number | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.previousRound(seasonId ?? "", currentRoundNumber ?? 0),
+    queryFn: () => getPreviousRound(seasonId!, currentRoundNumber!),
+    enabled: !!seasonId && !!currentRoundNumber && currentRoundNumber > 1,
+  });
+}

--- a/apps/mobile/src/queries/useRound.ts
+++ b/apps/mobile/src/queries/useRound.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRound } from "@/services/rounds";
+import { queryKeys } from "./keys";
+
+export function useRound(roundId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.roundDetail(roundId ?? ""),
+    queryFn: () => getRound(roundId!),
+    enabled: !!roundId,
+  });
+}

--- a/apps/mobile/src/queries/useRoundCountForSeason.ts
+++ b/apps/mobile/src/queries/useRoundCountForSeason.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoundCountForSeason } from "@/services/rounds";
+import { queryKeys } from "./keys";
+
+export function useRoundCountForSeason(seasonId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.seasonRoundCount(seasonId ?? ""),
+    queryFn: () => getRoundCountForSeason(seasonId!),
+    enabled: !!seasonId,
+  });
+}

--- a/apps/mobile/src/queries/useRoundResults.ts
+++ b/apps/mobile/src/queries/useRoundResults.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoundResults } from "@/services/results";
+import { queryKeys } from "./keys";
+
+export function useRoundResults(roundId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.roundResults(roundId ?? ""),
+    queryFn: () => getRoundResults(roundId!),
+    enabled: !!roundId,
+  });
+}

--- a/apps/mobile/src/queries/useRoundSubmissions.ts
+++ b/apps/mobile/src/queries/useRoundSubmissions.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoundSubmissions } from "@/services/votes";
+import { queryKeys } from "./keys";
+
+export function useRoundSubmissions(roundId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.roundSubmissions(roundId ?? ""),
+    queryFn: () => getRoundSubmissions(roundId!),
+    enabled: !!roundId,
+  });
+}

--- a/apps/mobile/src/queries/useRoundVoters.ts
+++ b/apps/mobile/src/queries/useRoundVoters.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoundVotersBySubmission } from "@/services/results";
+import { queryKeys } from "./keys";
+
+export function useRoundVoters(roundId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.roundVoters(roundId ?? ""),
+    queryFn: () => getRoundVotersBySubmission(roundId!),
+    enabled: !!roundId,
+  });
+}

--- a/apps/mobile/src/queries/useRoundsForSeason.ts
+++ b/apps/mobile/src/queries/useRoundsForSeason.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoundsForSeason } from "@/services/rounds";
+import { queryKeys } from "./keys";
+
+export function useRoundsForSeason(seasonId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.seasonRounds(seasonId ?? ""),
+    queryFn: () => getRoundsForSeason(seasonId!),
+    enabled: !!seasonId,
+  });
+}

--- a/apps/mobile/src/queries/useSeason.ts
+++ b/apps/mobile/src/queries/useSeason.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeason } from "@/services/seasons";
+import { queryKeys } from "./keys";
+
+export function useSeason(seasonId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.seasonDetail(seasonId ?? ""),
+    queryFn: () => getSeason(seasonId!),
+    enabled: !!seasonId,
+  });
+}

--- a/apps/mobile/src/queries/useSeasonAggregates.ts
+++ b/apps/mobile/src/queries/useSeasonAggregates.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeasonAggregates } from "@/services/standings";
+import { queryKeys } from "./keys";
+
+export function useSeasonAggregates(seasonId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.seasonAggregates(seasonId ?? ""),
+    queryFn: () => getSeasonAggregates(seasonId!),
+    enabled: !!seasonId,
+  });
+}

--- a/apps/mobile/src/queries/useSeasonStandings.ts
+++ b/apps/mobile/src/queries/useSeasonStandings.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeasonStandings } from "@/services/standings";
+import { queryKeys } from "./keys";
+
+export function useSeasonStandings(seasonId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.seasonStandings(seasonId ?? ""),
+    queryFn: () => getSeasonStandings(seasonId!),
+    enabled: !!seasonId,
+  });
+}

--- a/apps/mobile/src/queries/useSeasonsForLeague.ts
+++ b/apps/mobile/src/queries/useSeasonsForLeague.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSeasonsForLeague } from "@/services/seasons";
+import { queryKeys } from "./keys";
+
+export function useSeasonsForLeague(leagueId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.leagueSeasons(leagueId ?? ""),
+    queryFn: () => getSeasonsForLeague(leagueId!),
+    enabled: !!leagueId,
+  });
+}

--- a/apps/mobile/src/queries/useSubmitRoundEntries.ts
+++ b/apps/mobile/src/queries/useSubmitRoundEntries.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  submitRoundEntries,
+  type SubmitRoundEntriesArgs,
+} from "@/services/submissions";
+import { invalidations } from "./invalidation";
+
+export function useSubmitRoundEntries() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: SubmitRoundEntriesArgs) => submitRoundEntries(args),
+    onSuccess: (_data, variables) => {
+      invalidations.submitRoundEntries(qc, { roundId: variables.roundId });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useSubmitVotes.ts
+++ b/apps/mobile/src/queries/useSubmitVotes.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { submitVotes, type SubmitVotesArgs } from "@/services/votes";
+import { invalidations } from "./invalidation";
+
+export function useSubmitVotes() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: SubmitVotesArgs) => submitVotes(args),
+    onSuccess: (_data, variables) => {
+      invalidations.submitVotes(qc, { roundId: variables.roundId });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useUpdateRound.ts
+++ b/apps/mobile/src/queries/useUpdateRound.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateRound, type RoundUpdate } from "@/services/commissioner";
+import { invalidations } from "./invalidation";
+
+export function useUpdateRound() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      roundId: string;
+      seasonId?: string;
+      patch: RoundUpdate;
+    }) => updateRound(args.roundId, args.patch),
+    onSuccess: (_data, variables) => {
+      invalidations.updateRound(qc, {
+        roundId: variables.roundId,
+        seasonId: variables.seasonId,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useUpdateSeason.ts
+++ b/apps/mobile/src/queries/useUpdateSeason.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateSeason, type SeasonUpdate } from "@/services/commissioner";
+import { invalidations } from "./invalidation";
+
+export function useUpdateSeason() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { seasonId: string; patch: SeasonUpdate }) =>
+      updateSeason(args.seasonId, args.patch),
+    onSuccess: (_data, variables) => {
+      invalidations.updateSeason(qc, { seasonId: variables.seasonId });
+    },
+  });
+}

--- a/apps/mobile/src/screens/auth/AuthLoginScreen.tsx
+++ b/apps/mobile/src/screens/auth/AuthLoginScreen.tsx
@@ -1,10 +1,9 @@
 import { useRef, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert, TextInput } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
-import { loginWithSpotify, getValidAccessToken } from '@/lib/spotifyAuth';
-import { signInToSupabase } from '@/lib/supabaseAuth';
 import { useSession } from '@/context/SessionContext';
-import { supabase } from '@/lib/supabase';
+import { signInWithSpotify, signInWithPassword } from '@/services/auth';
+import { MixError } from '@/services/errors';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -30,12 +29,10 @@ export function AuthLoginScreen() {
   const handleSpotifyLogin = async () => {
     setLoading(true);
     try {
-      await loginWithSpotify();
-      const token = await getValidAccessToken();
-      if (token) await signInToSupabase(token);
+      await signInWithSpotify();
       await refresh();
     } catch (err) {
-      Alert.alert('Login failed', err instanceof Error ? err.message : 'Something went wrong');
+      Alert.alert('Login failed', err instanceof MixError ? err.message : 'Something went wrong');
     } finally {
       setLoading(false);
     }
@@ -45,11 +42,10 @@ export function AuthLoginScreen() {
     if (!email || !password) return;
     setLoading(true);
     try {
-      const { error } = await supabase.auth.signInWithPassword({ email, password });
-      if (error) throw error;
+      await signInWithPassword(email, password);
       await refresh();
     } catch (err) {
-      Alert.alert('Login failed', err instanceof Error ? err.message : 'Unknown error');
+      Alert.alert('Login failed', err instanceof MixError ? err.message : 'Unknown error');
     } finally {
       setLoading(false);
     }

--- a/apps/mobile/src/screens/create-league/CreateLeagueFlow.tsx
+++ b/apps/mobile/src/screens/create-league/CreateLeagueFlow.tsx
@@ -5,8 +5,10 @@ import {
 } from 'react-native';
 import { KeyboardScroll } from '@/components/KeyboardScroll';
 import { useRouter } from 'expo-router';
-import { supabase } from '@/lib/supabase';
 import { useLeague } from '@/context/LeagueContext';
+import { useSession } from '@/context/SessionContext';
+import { useCreateLeague } from '@/queries/useCreateLeague';
+import { MixError } from '@/services/errors';
 
 type PlaylistMode = 'fresh' | 'cloned' | 'linked';
 
@@ -29,8 +31,10 @@ function Field({ label, hint, children }: { label: string; hint?: string; childr
 export function CreateLeagueFlow() {
   const router = useRouter();
   const { setActiveLeagueId } = useLeague();
+  const { supabaseUserId } = useSession();
   const [form, setForm] = useState<LeagueForm>({ name: '', playlistMode: 'fresh', playlistRef: '' });
-  const [submitting, setSubmitting] = useState(false);
+  const createLeagueMutation = useCreateLeague();
+  const submitting = createLeagueMutation.isPending;
 
   const MODES: { value: PlaylistMode; label: string; desc: string }[] = [
     { value: 'fresh', label: 'Fresh', desc: 'Start a new playlist each season' },
@@ -40,25 +44,17 @@ export function CreateLeagueFlow() {
 
   const handleCreate = async () => {
     if (!form.name.trim()) return;
-    setSubmitting(true);
     try {
-      const { data: leagueId, error } = await supabase.rpc('create_league', { league_name: form.name.trim() });
-      if (error) throw new Error(error.message);
-      if (!leagueId) throw new Error('No league ID returned');
-
-      if (form.playlistMode !== 'fresh') {
-        await supabase.from('leagues').update({
-          master_playlist_mode: form.playlistMode,
-          master_playlist_ref: form.playlistRef || null,
-        }).eq('id', leagueId as string);
-      }
-
-      setActiveLeagueId(leagueId as string);
+      const leagueId = await createLeagueMutation.mutateAsync({
+        name: form.name.trim(),
+        masterPlaylistMode: form.playlistMode,
+        masterPlaylistRef: form.playlistRef || null,
+        userId: supabaseUserId ?? undefined,
+      });
+      setActiveLeagueId(leagueId);
       router.back();
     } catch (err) {
-      Alert.alert('Failed', err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setSubmitting(false);
+      Alert.alert('Failed', err instanceof MixError ? err.message : 'Unknown error');
     }
   };
 

--- a/apps/mobile/src/screens/create-season/CreateSeasonFlow.tsx
+++ b/apps/mobile/src/screens/create-season/CreateSeasonFlow.tsx
@@ -6,8 +6,10 @@ import {
 import { KeyboardScroll } from '@/components/KeyboardScroll';
 import RNDateTimePicker from '@react-native-community/datetimepicker';
 import { Stack, useRouter } from 'expo-router';
-import { supabase } from '@/lib/supabase';
 import { useLeague } from '@/context/LeagueContext';
+import { useCreateSeason } from '@/queries/useCreateSeason';
+import { hasInProgressSeason } from '@/services/seasons';
+import { MixError } from '@/services/errors';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -317,7 +319,8 @@ export function CreateSeasonFlow() {
   const router = useRouter();
   const { activeLeagueId } = useLeague();
   const [step, setStep] = useState<1 | 2>(1);
-  const [submitting, setSubmitting] = useState(false);
+  const createSeasonMutation = useCreateSeason();
+  const submitting = createSeasonMutation.isPending;
 
   const [season, setSeason] = useState<SeasonForm>(defaultSeason);
   const [rounds, setRounds] = useState<RoundForm[]>([makeRound(defaultSeason)]);
@@ -354,59 +357,32 @@ export function CreateSeasonFlow() {
 
   const handleSubmit = async () => {
     if (!activeLeagueId) return;
-    setSubmitting(true);
     try {
-      // FE guard: check for in-progress season before hitting the DB trigger
-      const { data: liveRounds } = await supabase
-        .from('rounds')
-        .select('id, seasons!inner(league_id)')
-        .gt('voting_deadline_at', new Date().toISOString())
-        .eq('seasons.league_id', activeLeagueId);
-
-      if (liveRounds && liveRounds.length > 0) {
+      if (await hasInProgressSeason(activeLeagueId)) {
         Alert.alert('Season in progress', 'A season is already running in this league. Wait for it to finish before creating a new one.');
         return;
       }
 
-      // Get current season count to set season_number
-      const { count } = await supabase
-        .from('seasons')
-        .select('id', { count: 'exact', head: true })
-        .eq('league_id', activeLeagueId!);
-
-      const { data: seasonData, error: seasonErr } = await supabase
-        .from('seasons')
-        .insert({
-          league_id: activeLeagueId!,
-          name: season.name,
-          season_number: (count ?? 0) + 1,
-          participant_cap: season.hasParticipantCap ? parseInt(season.participantCap) || null : null,
-          submissions_per_user: season.submissionsPerUser,
-          default_points_per_round: season.pointsPerRound,
-          default_max_points_per_track: season.maxPointsPerTrack,
-        })
-        .select('id')
-        .single();
-      if (seasonErr) throw new Error(seasonErr.message);
-
-      const { error: roundsErr } = await supabase.from('rounds').insert(
-        rounds.map((r, i) => ({
-          season_id: seasonData!.id,
-          round_number: i + 1,
+      await createSeasonMutation.mutateAsync({
+        leagueId: activeLeagueId,
+        name: season.name,
+        participantCap: season.hasParticipantCap
+          ? parseInt(season.participantCap) || null
+          : null,
+        submissionsPerUser: season.submissionsPerUser,
+        defaultPointsPerRound: season.pointsPerRound,
+        defaultMaxPointsPerTrack: season.maxPointsPerTrack,
+        rounds: rounds.map((r) => ({
           prompt: r.prompt,
           description: r.description.trim(),
-          submission_deadline_at: r.submissionDeadline.toISOString(),
-          voting_deadline_at: r.votingDeadline.toISOString(),
+          submissionDeadlineAt: r.submissionDeadline,
+          votingDeadlineAt: r.votingDeadline,
         })),
-      );
-      if (roundsErr) throw new Error(roundsErr.message);
+      });
 
-      // Go back to Home — LeagueScreen refetches on focus and shows the new season.
       router.back();
     } catch (err) {
-      Alert.alert('Failed', err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setSubmitting(false);
+      Alert.alert('Failed', err instanceof MixError ? err.message : 'Unknown error');
     }
   };
 

--- a/apps/mobile/src/screens/join/JoinScreen.tsx
+++ b/apps/mobile/src/screens/join/JoinScreen.tsx
@@ -1,33 +1,29 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
-import { supabase } from '@/lib/supabase';
 import { useLeague } from '@/context/LeagueContext';
+import { useSession } from '@/context/SessionContext';
+import { useJoinInviteInfo } from '@/queries/useJoinInviteInfo';
+import { useIsLeagueMember } from '@/queries/useIsLeagueMember';
+import { useJoinLeague } from '@/queries/useJoinLeague';
+import { MixError, NotAuthenticatedError } from '@/services/errors';
 import { SwipeSheet } from '@/components/SwipeSheet';
-
-type JoinInfo = {
-  seasonId: string;
-  seasonName: string;
-  seasonStatus: string;
-  leagueId: string;
-  leagueName: string;
-  alreadyMember: boolean;
-};
-
-type JoinInviteLookup = {
-  season_id: string;
-  season_name: string;
-  season_status: string;
-  league_id: string;
-  league_name: string;
-};
 
 export function JoinScreen({ token }: { token: string }) {
   const router = useRouter();
   const { setActiveLeagueId } = useLeague();
-  const [info, setInfo] = useState<JoinInfo | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [joining, setJoining] = useState(false);
+  const { supabaseUserId } = useSession();
+
+  const inviteQuery = useJoinInviteInfo(token);
+  const info = inviteQuery.data;
+  const memberQuery = useIsLeagueMember(
+    info?.leagueId,
+    supabaseUserId ?? undefined,
+  );
+  const alreadyMember = memberQuery.data === true;
+  const joinMutation = useJoinLeague();
+  const loading = inviteQuery.isPending || (!!info && memberQuery.isPending);
+  const joining = joinMutation.isPending;
 
   const handleClose = useCallback(() => {
     if (router.canGoBack()) {
@@ -37,63 +33,22 @@ export function JoinScreen({ token }: { token: string }) {
     router.replace('/(tabs)');
   }, [router]);
 
-  const fetchInfo = useCallback(async () => {
-    const { data, error } = await supabase
-      .rpc('get_join_invite_info' as never, { invite_token: token } as never)
-      .single();
-    const inviteInfo = data as JoinInviteLookup | null;
-
-    if (error || !inviteInfo) {
-      setLoading(false);
-      return;
-    }
-
-    const { data: { user } } = await supabase.auth.getUser();
-    let alreadyMember = false;
-    if (user) {
-      const { data: membership } = await supabase
-        .from('league_members')
-        .select('user_id')
-        .eq('league_id', inviteInfo.league_id)
-        .eq('user_id', user.id)
-        .maybeSingle();
-      alreadyMember = membership !== null;
-    }
-
-    setInfo({
-      seasonId: inviteInfo.season_id,
-      seasonName: inviteInfo.season_name,
-      seasonStatus: inviteInfo.season_status,
-      leagueId: inviteInfo.league_id,
-      leagueName: inviteInfo.league_name,
-      alreadyMember,
-    });
-    setLoading(false);
-  }, [token]);
-
-  useEffect(() => {
-    fetchInfo();
-  }, [fetchInfo]);
-
   const handleJoin = async (role: 'participant' | 'spectator') => {
     if (!info) return;
-    setJoining(true);
+    if (!supabaseUserId) {
+      Alert.alert('Failed to join', new NotAuthenticatedError().message);
+      return;
+    }
     try {
-      const { data: { user }, error: userErr } = await supabase.auth.getUser();
-      if (userErr || !user) throw new Error('Not authenticated');
-
-      const { error } = await supabase
-        .from('league_members')
-        .insert({ league_id: info.leagueId, user_id: user.id, role });
-
-      if (error) throw new Error(error.message);
-
+      await joinMutation.mutateAsync({
+        leagueId: info.leagueId,
+        userId: supabaseUserId,
+        role,
+      });
       setActiveLeagueId(info.leagueId);
       router.replace('/(tabs)');
     } catch (err) {
-      Alert.alert('Failed to join', err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setJoining(false);
+      Alert.alert('Failed to join', err instanceof MixError ? err.message : 'Unknown error');
     }
   };
 
@@ -121,7 +76,7 @@ export function JoinScreen({ token }: { token: string }) {
         </Text>
       </View>
     );
-  } else if (info.alreadyMember) {
+  } else if (alreadyMember) {
     content = (
       <View style={styles.stateBlock}>
         <Text style={styles.errorTitle}>Already a member</Text>

--- a/apps/mobile/src/screens/join/JoinScreen.tsx
+++ b/apps/mobile/src/screens/join/JoinScreen.tsx
@@ -30,7 +30,7 @@ export function JoinScreen({ token }: { token: string }) {
       router.back();
       return;
     }
-    router.replace('/(tabs)');
+    router.replace('/(tabs)/(home)');
   }, [router]);
 
   const handleJoin = async (role: 'participant' | 'spectator') => {
@@ -46,7 +46,7 @@ export function JoinScreen({ token }: { token: string }) {
         role,
       });
       setActiveLeagueId(info.leagueId);
-      router.replace('/(tabs)');
+      router.replace('/(tabs)/(home)');
     } catch (err) {
       Alert.alert('Failed to join', err instanceof MixError ? err.message : 'Unknown error');
     }
@@ -84,7 +84,7 @@ export function JoinScreen({ token }: { token: string }) {
         <TouchableOpacity
           style={styles.btn}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          onPress={() => { setActiveLeagueId(info.leagueId); router.replace('/(tabs)'); }}
+          onPress={() => { setActiveLeagueId(info.leagueId); router.replace('/(tabs)/(home)'); }}
         >
           <Text style={styles.btnText}>Go to League</Text>
         </TouchableOpacity>

--- a/apps/mobile/src/screens/league/LeagueScreen.tsx
+++ b/apps/mobile/src/screens/league/LeagueScreen.tsx
@@ -5,76 +5,42 @@ import {
 } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { supabase } from '@/lib/supabase';
-
-type League = { id: string; name: string; admin_user_id: string };
-
-type Season = {
-  id: string;
-  name: string;
-  season_number: number;
-  status: string;
-  invite_token: string;
-};
-
-type Member = {
-  user_id: string;
-  role: string;
-  display_name: string;
-};
+import { useSession } from '@/context/SessionContext';
+import { useLeague } from '@/queries/useLeague';
+import { useLeagueMembers } from '@/queries/useLeagueMembers';
+import { useSeasonsForLeague } from '@/queries/useSeasonsForLeague';
 
 export function LeagueScreen({ leagueId }: { leagueId: string }) {
   const router = useRouter();
+  const { supabaseUserId } = useSession();
 
-  const [supabaseUserId, setSupabaseUserId] = useState<string | null>(null);
-  const [league, setLeague] = useState<League | null>(null);
-  const [seasons, setSeasons] = useState<Season[]>([]);
-  const [members, setMembers] = useState<Member[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: league, isLoading: leagueLoading, refetch: refetchLeague } =
+    useLeague(leagueId);
+  const { data: seasons = [], refetch: refetchSeasons } =
+    useSeasonsForLeague(leagueId);
+  const { data: members = [], refetch: refetchMembers } =
+    useLeagueMembers(leagueId);
 
-  const fetchData = useCallback(async () => {
-    const [{ data: { user } }, { data: leagueData }, { data: seasonsData }, { data: membersData }] =
-      await Promise.all([
-        supabase.auth.getUser(),
-        supabase.from('leagues').select('id, name, admin_user_id').eq('id', leagueId).single(),
-        supabase
-          .from('seasons')
-          .select('id, name, season_number, status, invite_token')
-          .eq('league_id', leagueId)
-          .order('season_number', { ascending: false }),
-        supabase
-          .from('league_members')
-          .select('user_id, role, users(display_name)')
-          .eq('league_id', leagueId)
-          .order('joined_at', { ascending: true }),
-      ]);
-
-    setSupabaseUserId(user?.id ?? null);
-    setLeague(leagueData ?? null);
-    setSeasons(seasonsData ?? []);
-    setMembers(
-      (membersData ?? []).map((m) => ({
-        user_id: m.user_id,
-        role: m.role,
-        display_name:
-          (Array.isArray(m.users) ? m.users[0]?.display_name : (m.users as { display_name: string } | null)?.display_name) ?? 'Unknown',
-      })),
-    );
-    setLoading(false);
-  }, [leagueId]);
-
-  useFocusEffect(useCallback(() => { fetchData(); }, [fetchData]));
+  useFocusEffect(
+    useCallback(() => {
+      refetchLeague();
+      refetchSeasons();
+      refetchMembers();
+    }, [refetchLeague, refetchSeasons, refetchMembers]),
+  );
 
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await fetchData();
+    await Promise.all([refetchLeague(), refetchSeasons(), refetchMembers()]);
     setRefreshing(false);
-  }, [fetchData]);
+  }, [refetchLeague, refetchSeasons, refetchMembers]);
 
   const isCommissioner = league?.admin_user_id === supabaseUserId;
 
   const handleNewSeason = async () => {
-    // FE guard: check if any season still has live rounds
+    // FE guard: check if any season still has live rounds. Leaving this inline
+    // until the creation-flow slice; it's a one-off that doesn't reuse well.
     const { data: liveRounds } = await supabase
       .from('rounds')
       .select('id, seasons!inner(league_id)')
@@ -92,7 +58,7 @@ export function LeagueScreen({ leagueId }: { leagueId: string }) {
     router.push('/(tabs)/(home)/create-season' as any);
   };
 
-  if (loading) {
+  if (leagueLoading) {
     return <View style={styles.centered}><ActivityIndicator color="#555" /></View>;
   }
 
@@ -157,7 +123,7 @@ export function LeagueScreen({ leagueId }: { leagueId: string }) {
                   ]}>{season.status.toUpperCase()}</Text>
                 </View>
               </View>
-              {isCommissioner && season.status === 'active' && (
+              {isCommissioner && season.status === 'active' && season.invite_token && (
                 <TouchableOpacity
                   style={styles.shareBtn}
                   onPress={(e) => {

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -25,6 +25,11 @@ if (
 import { useRouter, useFocusEffect } from "expo-router";
 import { supabase } from "@/lib/supabase";
 import { getValidAccessToken } from "@/lib/spotifyAuth";
+import { useRoundSubmissions } from "@/queries/useRoundSubmissions";
+import { useMyVotes } from "@/queries/useMyVotes";
+import { useSubmitVotes } from "@/queries/useSubmitVotes";
+import { MixError } from "@/services/errors";
+import type { VoteInput, VoteCommentInput } from "@/services/votes";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -639,8 +644,9 @@ function VotingPhase({
 
   const [allocation, setAllocation] = useState<Record<string, number>>(() => myVotes);
   const [commentInputs, setCommentInputs] = useState<Record<string, string>>({});
-  const [submitting, setSubmitting] = useState(false);
   const [justSubmitted, setJustSubmitted] = useState(false);
+  const submitMutation = useSubmitVotes();
+  const submitting = submitMutation.isPending;
 
   const used = Object.values(allocation).reduce((a, b) => a + b, 0);
   const remaining = pointsTotal - used;
@@ -676,30 +682,15 @@ function VotingPhase({
       Alert.alert('Points not fully spent', `You have ${remaining} point${remaining !== 1 ? 's' : ''} left to allocate.`);
       return;
     }
-    const entries = Object.entries(allocation).filter(([, pts]) => pts > 0);
-    setSubmitting(true);
+    const votes: VoteInput[] = Object.entries(allocation)
+      .filter(([, pts]) => pts > 0)
+      .map(([submissionId, points]) => ({ submissionId, points }));
+    const comments: VoteCommentInput[] = submissions
+      .filter((s) => (commentInputs[s.id] ?? '').trim().length > 0)
+      .map((s) => ({ submissionId: s.id, body: commentInputs[s.id] }));
+
     try {
-      const votePayload = entries.map(([submission_id, points]) => ({ submission_id, points }));
-      const { error: voteError } = await supabase.rpc('submit_votes', {
-        p_round_id: round.id,
-        p_voter_user_id: userId,
-        p_votes: votePayload,
-      });
-      if (voteError) throw new Error(voteError.message);
-
-      const commentRows = submissions
-        .filter((s) => (commentInputs[s.id] ?? '').trim().length > 0)
-        .map((s) => ({
-          round_id: round.id,
-          submission_id: s.id,
-          author_user_id: userId,
-          body: commentInputs[s.id].trim(),
-        }));
-      if (commentRows.length > 0) {
-        const { error: commentError } = await supabase.from('comments').insert(commentRows);
-        if (commentError) throw new Error(commentError.message);
-      }
-
+      await submitMutation.mutateAsync({ roundId: round.id, userId, votes, comments });
       onScrollToTop?.();
       LayoutAnimation.configureNext({
         duration: 450,
@@ -710,9 +701,8 @@ function VotingPhase({
       setJustSubmitted(true);
       onVoted();
     } catch (err) {
-      Alert.alert('Submit failed', err instanceof Error ? err.message : 'Unknown error');
-    } finally {
-      setSubmitting(false);
+      const message = err instanceof MixError ? err.message : 'Unknown error';
+      Alert.alert('Submit failed', message);
     }
   };
 
@@ -1251,9 +1241,12 @@ export function RoundScreen({
   const [isCommissioner, setIsCommissioner] = useState(false);
   const [myRole, setMyRole] = useState<'participant' | 'spectator'>('participant');
   const [totalRounds, setTotalRounds] = useState(0);
-  const [submissions, setSubmissions] = useState<Submission[]>([]);
-  const [myVotes, setMyVotes] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
+
+  const { data: submissionsData, refetch: refetchSubmissions } = useRoundSubmissions(roundId);
+  const { data: myVotesData, refetch: refetchMyVotes } = useMyVotes(roundId, userId ?? undefined);
+  const submissions: Submission[] = submissionsData ?? [];
+  const myVotes = myVotesData ?? {};
 
   const fetchData = useCallback(async () => {
     const {
@@ -1304,48 +1297,29 @@ export function RoundScreen({
       setPrevRound(null);
     }
 
-    const [{ data: subData }, { data: voteData }, { count: roundCount }] = await Promise.all([
-      supabase
-        .from("submissions")
-        .select(
-          "id, user_id, track_title, track_artist, track_artwork_url, spotify_track_id, track_isrc, comment",
-        )
-        .eq("round_id", roundId),
-      supabase
-        .from("votes")
-        .select("submission_id, points")
-        .eq("round_id", roundId)
-        .eq("voter_user_id", user.id),
-      supabase
-        .from("rounds")
-        .select("id", { count: "exact", head: true })
-        .eq("season_id", r.season_id),
-    ]);
+    const { count: roundCount } = await supabase
+      .from("rounds")
+      .select("id", { count: "exact", head: true })
+      .eq("season_id", r.season_id);
 
     setTotalRounds(roundCount ?? 0);
-    setSubmissions(subData ?? []);
-
-    const voteMap: Record<string, number> = {};
-    (voteData ?? []).forEach(({ submission_id, points }) => {
-      voteMap[submission_id] = points;
-    });
-    setMyVotes(voteMap);
-
     setLoading(false);
   }, [roundId]);
 
   useFocusEffect(
     useCallback(() => {
       fetchData();
-    }, [fetchData]),
+      refetchSubmissions();
+      refetchMyVotes();
+    }, [fetchData, refetchSubmissions, refetchMyVotes]),
   );
 
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await fetchData();
+    await Promise.all([fetchData(), refetchSubmissions(), refetchMyVotes()]);
     setRefreshing(false);
-  }, [fetchData]);
+  }, [fetchData, refetchSubmissions, refetchMyVotes]);
 
   const scrollViewRef = useRef<ScrollView>(null);
   const scrollToTop = useCallback(() => {

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -24,12 +24,18 @@ if (
 }
 import { useRouter, useFocusEffect } from "expo-router";
 import { supabase } from "@/lib/supabase";
-import { getValidAccessToken } from "@/lib/spotifyAuth";
 import { useRoundSubmissions } from "@/queries/useRoundSubmissions";
 import { useMyVotes } from "@/queries/useMyVotes";
 import { useSubmitVotes } from "@/queries/useSubmitVotes";
+import { useSubmitRoundEntries } from "@/queries/useSubmitRoundEntries";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
+import type { SubmissionDraft } from "@/services/submissions";
+import {
+  searchSpotifyTracks,
+  getSpotifyTrack,
+  extractSpotifyTrackId,
+} from "@/services/spotifySearch";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -126,14 +132,6 @@ function formatDeadline(iso: string) {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function parseSpotifyTrackId(input: string): string | null {
-  const urlMatch = input.match(/spotify\.com\/track\/([a-zA-Z0-9]+)/);
-  if (urlMatch) return urlMatch[1];
-  const uriMatch = input.match(/spotify:track:([a-zA-Z0-9]+)/);
-  if (uriMatch) return uriMatch[1];
-  return null;
 }
 
 function submissionToTrack(submission: Submission): SpotifyTrack {
@@ -240,9 +238,10 @@ function SubmissionPhase({
 }) {
   const submissionsPerUser = round.seasons?.submissions_per_user ?? 1;
   const router = useRouter();
-  const [submitting, setSubmitting] = useState(false);
   const [drafts, setDrafts] = useState<DraftSubmission[]>([]);
   const searchRequestIds = useRef<Record<number, number>>({});
+  const submitMutation = useSubmitRoundEntries();
+  const submitting = submitMutation.isPending;
 
   const baselineDrafts = useMemo(
     () =>
@@ -299,32 +298,10 @@ function SubmissionPhase({
       setSearchState(slotIndex, { isSearching: true });
 
       try {
-        const token = await getValidAccessToken();
-        if (!token) throw new Error("Not logged in to Spotify");
-
-        const linkedTrackId = parseSpotifyTrackId(trimmed);
-        let nextResults: SpotifyTrack[] = [];
-
-        if (linkedTrackId) {
-          const res = await fetch(
-            `https://api.spotify.com/v1/tracks/${linkedTrackId}`,
-            {
-              headers: { Authorization: `Bearer ${token}` },
-            },
-          );
-          if (!res.ok) throw new Error(`Spotify lookup failed (${res.status})`);
-          const track = (await res.json()) as SpotifyTrack;
-          nextResults = [track];
-        } else {
-          const res = await fetch(
-            `https://api.spotify.com/v1/search?q=${encodeURIComponent(trimmed)}&type=track&limit=8`,
-            { headers: { Authorization: `Bearer ${token}` } },
-          );
-          const data = (await res.json()) as {
-            tracks?: { items: SpotifyTrack[] };
-          };
-          nextResults = data.tracks?.items ?? [];
-        }
+        const linkedTrackId = extractSpotifyTrackId(trimmed);
+        const nextResults = linkedTrackId
+          ? [await getSpotifyTrack(linkedTrackId)]
+          : await searchSpotifyTracks(trimmed);
 
         if (searchRequestIds.current[slotIndex] !== requestId) return;
         setSearchState(slotIndex, {
@@ -334,10 +311,8 @@ function SubmissionPhase({
       } catch (err) {
         if (searchRequestIds.current[slotIndex] !== requestId) return;
         setSearchState(slotIndex, { isSearching: false, searchResults: [] });
-        Alert.alert(
-          "Search failed",
-          err instanceof Error ? err.message : "Unknown error",
-        );
+        const message = err instanceof MixError ? err.message : "Unknown error";
+        Alert.alert("Search failed", message);
       }
     },
     [setSearchState],
@@ -431,65 +406,36 @@ function SubmissionPhase({
       return;
     }
 
-    setSubmitting(true);
+    const payload: SubmissionDraft[] = drafts
+      .filter((d) => d.track)
+      .map((d) => {
+        const t = d.track as SpotifyTrack;
+        return {
+          submissionId: d.submissionId,
+          track: {
+            spotifyTrackId: t.id,
+            title: t.name,
+            artist: t.artists.map((a) => a.name).join(", "),
+            artworkUrl: t.album.images[0]?.url ?? null,
+            isrc: t.external_ids?.isrc ?? null,
+            albumName: t.album.name || null,
+            durationMs: t.duration_ms || null,
+            popularity: t.popularity || null,
+          },
+          comment: d.comment,
+        };
+      });
+
     try {
-      const updates = drafts
-        .filter((draft) => draft.submissionId && draft.track)
-        .map((draft) => {
-          const track = draft.track as SpotifyTrack;
-          return supabase
-            .from("submissions")
-            .update({
-              spotify_track_id: track.id,
-              track_title: track.name,
-              track_artist: track.artists.map((a) => a.name).join(", "),
-              track_artwork_url: track.album.images[0]?.url ?? null,
-              track_isrc: track.external_ids?.isrc ?? "",
-              track_album_name: track.album.name,
-              track_duration_ms: track.duration_ms,
-              track_popularity: track.popularity,
-              comment: draft.comment.trim() || null,
-            })
-            .eq("id", draft.submissionId as string)
-            .eq("user_id", userId);
-        });
-
-      const inserts = drafts
-        .filter((draft) => !draft.submissionId && draft.track)
-        .map((draft) => {
-          const track = draft.track as SpotifyTrack;
-          return {
-            round_id: round.id,
-            user_id: userId,
-            spotify_track_id: track.id,
-            track_title: track.name,
-            track_artist: track.artists.map((a) => a.name).join(", "),
-            track_artwork_url: track.album.images[0]?.url ?? null,
-            track_isrc: track.external_ids?.isrc ?? "",
-            track_album_name: track.album.name,
-            track_duration_ms: track.duration_ms,
-            track_popularity: track.popularity,
-            comment: draft.comment.trim() || null,
-          };
-        });
-
-      const updateResults = await Promise.all(updates);
-      const updateError = updateResults.find(({ error }) => error)?.error;
-      if (updateError) throw new Error(updateError.message);
-
-      if (inserts.length > 0) {
-        const { error } = await supabase.from("submissions").insert(inserts);
-        if (error) throw new Error(error.message);
-      }
-
+      await submitMutation.mutateAsync({
+        roundId: round.id,
+        userId,
+        drafts: payload,
+      });
       onSubmitted();
     } catch (err) {
-      Alert.alert(
-        "Submission failed",
-        err instanceof Error ? err.message : "Unknown error",
-      );
-    } finally {
-      setSubmitting(false);
+      const message = err instanceof MixError ? err.message : "Unknown error";
+      Alert.alert("Submission failed", message);
     }
   };
 

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -24,10 +24,16 @@ if (
 }
 import { useRouter, useFocusEffect } from "expo-router";
 import { supabase } from "@/lib/supabase";
+import { useSession } from "@/context/SessionContext";
 import { useRoundSubmissions } from "@/queries/useRoundSubmissions";
 import { useMyVotes } from "@/queries/useMyVotes";
 import { useSubmitVotes } from "@/queries/useSubmitVotes";
 import { useSubmitRoundEntries } from "@/queries/useSubmitRoundEntries";
+import { useRound } from "@/queries/useRound";
+import { usePreviousRound } from "@/queries/usePreviousRound";
+import { useRoundCountForSeason } from "@/queries/useRoundCountForSeason";
+import { useLeague } from "@/queries/useLeague";
+import { useMyRole } from "@/queries/useMyRole";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
 import type { SubmissionDraft } from "@/services/submissions";
@@ -1181,98 +1187,89 @@ export function RoundScreen({
   seasonId?: string;
 }) {
   const router = useRouter();
-  const [round, setRound] = useState<Round | null>(null);
-  const [prevRound, setPrevRound] = useState<SiblingRound | null>(null);
-  const [userId, setUserId] = useState<string | null>(null);
-  const [isCommissioner, setIsCommissioner] = useState(false);
-  const [myRole, setMyRole] = useState<'participant' | 'spectator'>('participant');
-  const [totalRounds, setTotalRounds] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const { supabaseUserId } = useSession();
+  const userId = supabaseUserId;
 
-  const { data: submissionsData, refetch: refetchSubmissions } = useRoundSubmissions(roundId);
-  const { data: myVotesData, refetch: refetchMyVotes } = useMyVotes(roundId, userId ?? undefined);
+  const { data: round, isLoading: roundLoading, refetch: refetchRound } =
+    useRound(roundId);
+  const roundSeasonId = round?.season_id;
+  const leagueId = round?.seasons?.league_id;
+
+  const { data: prevRound, refetch: refetchPrevRound } = usePreviousRound(
+    roundSeasonId,
+    round?.round_number,
+  );
+  const { data: league, refetch: refetchLeague } = useLeague(leagueId);
+  const { data: myRoleData, refetch: refetchMyRole } = useMyRole(
+    leagueId,
+    userId ?? undefined,
+  );
+  const { data: totalRoundsData, refetch: refetchTotalRounds } =
+    useRoundCountForSeason(roundSeasonId);
+
+  const isCommissioner = !!userId && league?.admin_user_id === userId;
+  const myRole: "participant" | "spectator" =
+    myRoleData === "spectator" ? "spectator" : "participant";
+  const totalRounds = totalRoundsData ?? 0;
+
+  const { data: submissionsData, refetch: refetchSubmissions } =
+    useRoundSubmissions(roundId);
+  const { data: myVotesData, refetch: refetchMyVotes } = useMyVotes(
+    roundId,
+    userId ?? undefined,
+  );
   const submissions: Submission[] = submissionsData ?? [];
   const myVotes = myVotesData ?? {};
 
-  const fetchData = useCallback(async () => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-    setUserId(user.id);
-
-    const { data: roundData } = await supabase
-      .from("rounds")
-      .select(
-        "id, round_number, prompt, description, submission_deadline_at, voting_deadline_at, season_id, seasons(id, name, status, submissions_per_user, default_points_per_round, default_max_points_per_track, league_id)",
-      )
-      .eq("id", roundId)
-      .single();
-
-    if (!roundData) {
-      setLoading(false);
-      return;
-    }
-
-    const season = Array.isArray(roundData.seasons)
-      ? roundData.seasons[0]
-      : roundData.seasons;
-    const r: Round = { ...roundData, seasons: season ?? null };
-    setRound(r);
-
-    // Check commissioner status and league role in parallel
-    if (season?.league_id && user) {
-      const [{ data: leagueData }, { data: memberData }] = await Promise.all([
-        supabase.from("leagues").select("admin_user_id").eq("id", season.league_id).single(),
-        supabase.from("league_members").select("role").eq("league_id", season.league_id).eq("user_id", user.id).single(),
-      ]);
-      setIsCommissioner(leagueData?.admin_user_id === user.id);
-      setMyRole(memberData?.role === 'spectator' ? 'spectator' : 'participant');
-    }
-
-    // Fetch previous round to determine if this one is open
-    if (r.round_number > 1) {
-      const { data: prev } = await supabase
-        .from("rounds")
-        .select("id, round_number, prompt, voting_deadline_at")
-        .eq("season_id", r.season_id)
-        .eq("round_number", r.round_number - 1)
-        .single();
-      setPrevRound(prev ?? null);
-    } else {
-      setPrevRound(null);
-    }
-
-    const { count: roundCount } = await supabase
-      .from("rounds")
-      .select("id", { count: "exact", head: true })
-      .eq("season_id", r.season_id);
-
-    setTotalRounds(roundCount ?? 0);
-    setLoading(false);
-  }, [roundId]);
-
   useFocusEffect(
     useCallback(() => {
-      fetchData();
+      refetchRound();
+      refetchPrevRound();
+      refetchLeague();
+      refetchMyRole();
+      refetchTotalRounds();
       refetchSubmissions();
       refetchMyVotes();
-    }, [fetchData, refetchSubmissions, refetchMyVotes]),
+    }, [
+      refetchRound,
+      refetchPrevRound,
+      refetchLeague,
+      refetchMyRole,
+      refetchTotalRounds,
+      refetchSubmissions,
+      refetchMyVotes,
+    ]),
   );
 
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await Promise.all([fetchData(), refetchSubmissions(), refetchMyVotes()]);
+    await Promise.all([
+      refetchRound(),
+      refetchPrevRound(),
+      refetchLeague(),
+      refetchMyRole(),
+      refetchTotalRounds(),
+      refetchSubmissions(),
+      refetchMyVotes(),
+    ]);
     setRefreshing(false);
-  }, [fetchData, refetchSubmissions, refetchMyVotes]);
+  }, [
+    refetchRound,
+    refetchPrevRound,
+    refetchLeague,
+    refetchMyRole,
+    refetchTotalRounds,
+    refetchSubmissions,
+    refetchMyVotes,
+  ]);
 
   const scrollViewRef = useRef<ScrollView>(null);
   const scrollToTop = useCallback(() => {
     scrollViewRef.current?.scrollTo({ y: 0, animated: true });
   }, []);
 
-  if (loading) {
+  if (roundLoading) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator color="#555" />
@@ -1288,7 +1285,7 @@ export function RoundScreen({
     );
   }
 
-  const phase = getPhase(round, prevRound);
+  const phase = getPhase(round, prevRound ?? null);
   const mySubmissions = submissions.filter((s) => s.user_id === userId);
 
   const phaseColor: Record<Phase, string> = {
@@ -1318,7 +1315,7 @@ export function RoundScreen({
               .from("rounds")
               .update({ voting_deadline_at: new Date().toISOString() })
               .eq("id", round.id);
-            fetchData();
+            refetchRound();
           },
         },
       ],
@@ -1423,7 +1420,7 @@ export function RoundScreen({
           myVotes={myVotes}
           didSubmit={mySubmissions.length > 0}
           isSpectator={myRole === 'spectator'}
-          onVoted={fetchData}
+          onVoted={refetchRound}
           onScrollToTop={scrollToTop}
         />
       )}

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -36,6 +36,7 @@ import { useLeague } from "@/queries/useLeague";
 import { useMyRole } from "@/queries/useMyRole";
 import { useRoundResults } from "@/queries/useRoundResults";
 import { useRoundVoters } from "@/queries/useRoundVoters";
+import { useForceEndRound } from "@/queries/useForceEndRound";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
 import type { SubmissionDraft } from "@/services/submissions";
@@ -1247,7 +1248,9 @@ export function RoundScreen({
     upcoming: "NOT STARTED YET",
   };
 
-  const forceCloseVoting = async () => {
+  const forceEndRoundMutation = useForceEndRound();
+
+  const forceCloseVoting = () => {
     Alert.alert(
       "Force end voting?",
       "This will immediately close the voting window and move the round to results.",
@@ -1257,11 +1260,17 @@ export function RoundScreen({
           text: "End Voting",
           style: "destructive",
           onPress: async () => {
-            await supabase
-              .from("rounds")
-              .update({ voting_deadline_at: new Date().toISOString() })
-              .eq("id", round.id);
-            refetchRound();
+            try {
+              await forceEndRoundMutation.mutateAsync({
+                roundId: round.id,
+                seasonId: round.season_id,
+              });
+            } catch (err) {
+              Alert.alert(
+                "Failed to end voting",
+                err instanceof MixError ? err.message : "Unknown error",
+              );
+            }
           },
         },
       ],

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -34,6 +34,8 @@ import { usePreviousRound } from "@/queries/usePreviousRound";
 import { useRoundCountForSeason } from "@/queries/useRoundCountForSeason";
 import { useLeague } from "@/queries/useLeague";
 import { useMyRole } from "@/queries/useMyRole";
+import { useRoundResults } from "@/queries/useRoundResults";
+import { useRoundVoters } from "@/queries/useRoundVoters";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
 import type { SubmissionDraft } from "@/services/submissions";
@@ -880,75 +882,19 @@ type RoundResultRow = {
 };
 
 function ResultsPhase({ submissions, roundId }: { submissions: Submission[]; roundId: string }) {
-  const [results, setResults] = useState<RoundResultRow[]>([]);
-  const [votersBySubmission, setVotersBySubmission] = useState<Record<string, VoterEntry[]>>({});
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const resultsQuery = useRoundResults(roundId);
+  const votersQuery = useRoundVoters(roundId);
+  const results = resultsQuery.data ?? [];
+  const votersBySubmission = votersQuery.data ?? {};
+  const loading = resultsQuery.isPending || votersQuery.isPending;
+  const loadError =
+    resultsQuery.error instanceof Error ? resultsQuery.error.message : null;
 
   const submissionCommentById = useMemo(() => {
     const map: Record<string, string | null> = {};
     submissions.forEach((s) => { map[s.id] = s.comment; });
     return map;
   }, [submissions]);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoadError(null);
-    setLoading(true);
-
-    Promise.all([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (supabase.rpc as any)('get_round_results', { p_round_id: roundId }),
-      supabase
-        .from('votes')
-        .select('submission_id, points, voter_user_id, users(display_name)')
-        .eq('round_id', roundId),
-      supabase
-        .from('comments')
-        .select('submission_id, body, author_user_id')
-        .eq('round_id', roundId),
-    ]).then(([rpcRes, votesRes, commentsRes]) => {
-      if (cancelled) return;
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const err = (rpcRes as any).error;
-      if (err) {
-        setLoadError(err.message ?? 'Could not load results');
-        setResults([]);
-        setVotersBySubmission({});
-        setLoading(false);
-        return;
-      }
-
-      const commentLookup: Record<string, Record<string, string>> = {};
-      (commentsRes.data ?? []).forEach((c) => {
-        if (!commentLookup[c.submission_id]) commentLookup[c.submission_id] = {};
-        commentLookup[c.submission_id][c.author_user_id] = c.body;
-      });
-
-      const voterMap: Record<string, VoterEntry[]> = {};
-      (votesRes.data ?? []).forEach((v) => {
-        if (!voterMap[v.submission_id]) voterMap[v.submission_id] = [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const name = (Array.isArray(v.users) ? (v.users[0] as any)?.display_name : (v.users as any)?.display_name) ?? 'Unknown';
-        voterMap[v.submission_id].push({
-          voter_user_id: v.voter_user_id,
-          voter_name: name,
-          points: v.points,
-          comment: commentLookup[v.submission_id]?.[v.voter_user_id] ?? null,
-        });
-      });
-      Object.values(voterMap).forEach((entries) =>
-        entries.sort((a, b) => b.points - a.points),
-      );
-
-      setResults((rpcRes.data ?? []) as unknown as RoundResultRow[]);
-      setVotersBySubmission(voterMap);
-      setLoading(false);
-    });
-
-    return () => { cancelled = true; };
-  }, [roundId]);
 
   // Sort defensively so ranking never depends on RPC row order.
   const eligible = useMemo(

--- a/apps/mobile/src/screens/season/SeasonScreen.tsx
+++ b/apps/mobile/src/screens/season/SeasonScreen.tsx
@@ -13,6 +13,10 @@ import { useRoundsForSeason } from '@/queries/useRoundsForSeason';
 import { useLeagueMembers } from '@/queries/useLeagueMembers';
 import { useSeasonStandings } from '@/queries/useSeasonStandings';
 import { useSeasonAggregates } from '@/queries/useSeasonAggregates';
+import { useUpdateSeason } from '@/queries/useUpdateSeason';
+import { useUpdateRound } from '@/queries/useUpdateRound';
+import { useCreateRound } from '@/queries/useCreateRound';
+import { MixError } from '@/services/errors';
 
 type Season = {
   id: string;
@@ -201,21 +205,26 @@ function SeasonEditModal({ season, visible, onClose, onSaved }: {
     pointsPerRound: season.default_points_per_round,
     maxPerTrack: season.default_max_points_per_track,
   });
-  const [saving, setSaving] = useState(false);
+  const updateSeasonMutation = useUpdateSeason();
+  const saving = updateSeasonMutation.isPending;
 
   const save = async () => {
     if (!form.name.trim()) { Alert.alert('Name required'); return; }
-    setSaving(true);
-    const { error } = await supabase.from('seasons').update({
-      name: form.name.trim(),
-      submissions_per_user: form.submissionsPerUser,
-      default_points_per_round: form.pointsPerRound,
-      default_max_points_per_track: form.maxPerTrack,
-    }).eq('id', season.id);
-    setSaving(false);
-    if (error) { Alert.alert('Save failed', error.message); return; }
-    onSaved();
-    onClose();
+    try {
+      await updateSeasonMutation.mutateAsync({
+        seasonId: season.id,
+        patch: {
+          name: form.name.trim(),
+          submissionsPerUser: form.submissionsPerUser,
+          defaultPointsPerRound: form.pointsPerRound,
+          defaultMaxPointsPerTrack: form.maxPerTrack,
+        },
+      });
+      onSaved();
+      onClose();
+    } catch (err) {
+      Alert.alert('Save failed', err instanceof MixError ? err.message : 'Unknown error');
+    }
   };
 
   return (
@@ -309,7 +318,10 @@ function RoundFormModal({ mode, visible, onClose, onSaved }: {
         }
       : defaultCreateForm(),
   );
-  const [saving, setSaving] = useState(false);
+  const updateRoundMutation = useUpdateRound();
+  const createRoundMutation = useCreateRound();
+  const saving =
+    updateRoundMutation.isPending || createRoundMutation.isPending;
 
   const save = async () => {
     if (!form.prompt.trim()) { Alert.alert('Prompt required'); return; }
@@ -318,29 +330,35 @@ function RoundFormModal({ mode, visible, onClose, onSaved }: {
       Alert.alert('Voting deadline must be after submission deadline'); return;
     }
 
-    setSaving(true);
-    const { error } = mode.kind === 'edit'
-      ? await supabase.from('rounds').update({
-          prompt: form.prompt.trim(),
-          description: form.description.trim(),
-          submission_deadline_at: form.submissionDeadline.toISOString(),
-          voting_deadline_at: form.votingDeadline.toISOString(),
-        }).eq('id', mode.round.id)
-      : await supabase.from('rounds').insert({
-          season_id: mode.seasonId,
-          round_number: mode.nextRoundNumber,
-          prompt: form.prompt.trim(),
-          description: form.description.trim(),
-          submission_deadline_at: form.submissionDeadline.toISOString(),
-          voting_deadline_at: form.votingDeadline.toISOString(),
+    try {
+      if (mode.kind === 'edit') {
+        await updateRoundMutation.mutateAsync({
+          roundId: mode.round.id,
+          patch: {
+            prompt: form.prompt.trim(),
+            description: form.description.trim(),
+            submissionDeadlineAt: form.submissionDeadline,
+            votingDeadlineAt: form.votingDeadline,
+          },
         });
-    setSaving(false);
-    if (error) {
-      Alert.alert(mode.kind === 'edit' ? 'Save failed' : 'Create failed', error.message);
-      return;
+      } else {
+        await createRoundMutation.mutateAsync({
+          seasonId: mode.seasonId,
+          roundNumber: mode.nextRoundNumber,
+          prompt: form.prompt.trim(),
+          description: form.description.trim(),
+          submissionDeadlineAt: form.submissionDeadline,
+          votingDeadlineAt: form.votingDeadline,
+        });
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      Alert.alert(
+        mode.kind === 'edit' ? 'Save failed' : 'Create failed',
+        err instanceof MixError ? err.message : 'Unknown error',
+      );
     }
-    onSaved();
-    onClose();
   };
 
   const title = mode.kind === 'edit'

--- a/apps/mobile/src/screens/season/SeasonScreen.tsx
+++ b/apps/mobile/src/screens/season/SeasonScreen.tsx
@@ -7,6 +7,10 @@ import { KeyboardScroll } from '@/components/KeyboardScroll'; // used inside mod
 import RNDateTimePicker from '@react-native-community/datetimepicker';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { supabase } from '@/lib/supabase';
+import { useSession } from '@/context/SessionContext';
+import { useSeason } from '@/queries/useSeason';
+import { useRoundsForSeason } from '@/queries/useRoundsForSeason';
+import { useLeagueMembers } from '@/queries/useLeagueMembers';
 
 type Season = {
   id: string;
@@ -397,57 +401,35 @@ type Tab = 'rounds' | 'standings';
 export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initialTab?: Tab }) {
   const router = useRouter();
 
-  const [userId, setUserId] = useState<string | null>(null);
-  const [season, setSeason] = useState<Season | null>(null);
-  const [rounds, setRounds] = useState<Round[]>([]);
-  const [members, setMembers] = useState<Member[]>([]);
+  const { supabaseUserId: userId } = useSession();
+  const { data: season, isLoading: seasonLoading, refetch: refetchSeason } =
+    useSeason(seasonId);
+  const { data: rounds = [], refetch: refetchRounds } =
+    useRoundsForSeason(seasonId);
+  const leagueId = season?.league_id;
+  const { data: members = [], refetch: refetchMembers } =
+    useLeagueMembers(leagueId);
+
   const [standings, setStandings] = useState<StandingRow[]>([]);
   const [submittersByRound, setSubmittersByRound] = useState<Record<string, string[]>>({});
   const [votersByRound, setVotersByRound] = useState<Record<string, string[]>>({});
   const [forfeitsByRound, setForfeitsByRound] = useState<Record<string, number>>({});
-  const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<Tab>(initialTab ?? 'rounds');
 
   const [editingSeasonOpen, setEditingSeasonOpen] = useState(false);
   const [editingRound, setEditingRound] = useState<Round | null>(null);
   const [creatingRound, setCreatingRound] = useState(false);
 
-  const fetchData = useCallback(async () => {
-    const [{ data: { user } }, { data: rawSeasonData }] = await Promise.all([
-      supabase.auth.getUser(),
-      supabase
-        .from('seasons')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .select('id, name, season_number, status, league_id, submissions_per_user, default_points_per_round, default_max_points_per_track, leagues(id, name, admin_user_id)' as any)
-        .eq('id', seasonId)
-        .single(),
-    ]);
-
-    setUserId(user?.id ?? null);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const seasonData = rawSeasonData as any as (Season & { leagues: any }) | null;
-
-    if (!seasonData) { setLoading(false); return; }
-
-    const league = Array.isArray(seasonData.leagues) ? seasonData.leagues[0] : seasonData.leagues;
-
-    const [{ data: roundsData }, { data: membersData }, standingsRes] = await Promise.all([
-      supabase
-        .from('rounds')
-        .select('id, round_number, prompt, description, submission_deadline_at, voting_deadline_at')
-        .eq('season_id', seasonId)
-        .order('round_number', { ascending: true }),
-      supabase
-        .from('league_members')
-        .select('user_id, role, users(display_name)')
-        .eq('league_id', seasonData.league_id)
-        .order('joined_at', { ascending: true }),
+  // Standings + per-round aggregates still inline — they'll move to the
+  // results/standings slice.
+  const fetchAggregates = useCallback(async () => {
+    const [standingsRes, roundsForAggRes] = await Promise.all([
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (supabase.rpc as any)('get_season_standings', { p_season_id: seasonId }),
+      supabase.from('rounds').select('id').eq('season_id', seasonId),
     ]);
 
-    const roundIds = (roundsData ?? []).map((r) => r.id);
+    const roundIds = (roundsForAggRes.data ?? []).map((r: { id: string }) => r.id);
     const [
       { data: subsData },
       { data: votesData },
@@ -460,41 +442,23 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
         ])
       : [{ data: [] }, { data: [] }, { data: [] }];
 
-    // Build map: roundId → unique user_ids who submitted
     const byRound: Record<string, string[]> = {};
     for (const sub of (subsData ?? [])) {
       if (!byRound[sub.round_id]) byRound[sub.round_id] = [];
       if (!byRound[sub.round_id].includes(sub.user_id)) byRound[sub.round_id].push(sub.user_id);
     }
-
-    // Build map: roundId → unique voter_user_ids
     const votersBy: Record<string, string[]> = {};
     for (const v of (votesData ?? [])) {
       if (!votersBy[v.round_id]) votersBy[v.round_id] = [];
       if (!votersBy[v.round_id].includes(v.voter_user_id)) votersBy[v.round_id].push(v.voter_user_id);
     }
-
-    // Build map: roundId → forfeit count (participants flagged is_void)
     const forfeitsBy: Record<string, number> = {};
     for (const p of (participantsData ?? [])) {
       if (p.is_void) forfeitsBy[p.round_id] = (forfeitsBy[p.round_id] ?? 0) + 1;
     }
-
-    setSeason({ ...seasonData, leagues: league ?? null });
-    setRounds(roundsData ?? []);
     setSubmittersByRound(byRound);
     setVotersByRound(votersBy);
     setForfeitsByRound(forfeitsBy);
-    setMembers(
-      (membersData ?? []).map((m) => ({
-        user_id: m.user_id,
-        role: m.role,
-        display_name:
-          (Array.isArray(m.users)
-            ? m.users[0]?.display_name
-            : (m.users as { display_name: string } | null)?.display_name) ?? 'Unknown',
-      })),
-    );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sr = standingsRes as any;
@@ -504,18 +468,39 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
     } else {
       setStandings(Array.isArray(sr.data) ? sr.data : []);
     }
-
-    setLoading(false);
   }, [seasonId]);
 
-  useFocusEffect(useCallback(() => { fetchData(); }, [fetchData]));
+  useFocusEffect(
+    useCallback(() => {
+      refetchSeason();
+      refetchRounds();
+      refetchMembers();
+      fetchAggregates();
+    }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]),
+  );
 
   const [refreshing, setRefreshing] = useState(false);
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await fetchData();
+    await Promise.all([
+      refetchSeason(),
+      refetchRounds(),
+      refetchMembers(),
+      fetchAggregates(),
+    ]);
     setRefreshing(false);
-  }, [fetchData]);
+  }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]);
+
+  const loading = seasonLoading;
+
+  const refetchAll = useCallback(async () => {
+    await Promise.all([
+      refetchSeason(),
+      refetchRounds(),
+      refetchMembers(),
+      fetchAggregates(),
+    ]);
+  }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]);
 
   const sortedByRoundNumber = useMemo(
     () => [...rounds].sort((a, b) => a.round_number - b.round_number),
@@ -793,7 +778,7 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
           season={season}
           visible={editingSeasonOpen}
           onClose={() => setEditingSeasonOpen(false)}
-          onSaved={fetchData}
+          onSaved={refetchAll}
         />
       )}
 
@@ -803,7 +788,7 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
           mode={{ kind: 'edit', round: editingRound }}
           visible={editingRound !== null}
           onClose={() => setEditingRound(null)}
-          onSaved={fetchData}
+          onSaved={refetchAll}
         />
       )}
 
@@ -817,7 +802,7 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
           }}
           visible={creatingRound}
           onClose={() => setCreatingRound(false)}
-          onSaved={fetchData}
+          onSaved={refetchAll}
         />
       )}
     </View>

--- a/apps/mobile/src/screens/season/SeasonScreen.tsx
+++ b/apps/mobile/src/screens/season/SeasonScreen.tsx
@@ -11,6 +11,8 @@ import { useSession } from '@/context/SessionContext';
 import { useSeason } from '@/queries/useSeason';
 import { useRoundsForSeason } from '@/queries/useRoundsForSeason';
 import { useLeagueMembers } from '@/queries/useLeagueMembers';
+import { useSeasonStandings } from '@/queries/useSeasonStandings';
+import { useSeasonAggregates } from '@/queries/useSeasonAggregates';
 
 type Season = {
   id: string;
@@ -410,73 +412,38 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
   const { data: members = [], refetch: refetchMembers } =
     useLeagueMembers(leagueId);
 
-  const [standings, setStandings] = useState<StandingRow[]>([]);
-  const [submittersByRound, setSubmittersByRound] = useState<Record<string, string[]>>({});
-  const [votersByRound, setVotersByRound] = useState<Record<string, string[]>>({});
-  const [forfeitsByRound, setForfeitsByRound] = useState<Record<string, number>>({});
+  const { data: standings = [], refetch: refetchStandings } =
+    useSeasonStandings(seasonId);
+  const {
+    data: aggregates = {
+      submittersByRound: {},
+      votersByRound: {},
+      forfeitsByRound: {},
+    },
+    refetch: refetchAggregates,
+  } = useSeasonAggregates(seasonId);
+  const { submittersByRound, votersByRound, forfeitsByRound } = aggregates;
+
   const [tab, setTab] = useState<Tab>(initialTab ?? 'rounds');
 
   const [editingSeasonOpen, setEditingSeasonOpen] = useState(false);
   const [editingRound, setEditingRound] = useState<Round | null>(null);
   const [creatingRound, setCreatingRound] = useState(false);
 
-  // Standings + per-round aggregates still inline — they'll move to the
-  // results/standings slice.
-  const fetchAggregates = useCallback(async () => {
-    const [standingsRes, roundsForAggRes] = await Promise.all([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (supabase.rpc as any)('get_season_standings', { p_season_id: seasonId }),
-      supabase.from('rounds').select('id').eq('season_id', seasonId),
-    ]);
-
-    const roundIds = (roundsForAggRes.data ?? []).map((r: { id: string }) => r.id);
-    const [
-      { data: subsData },
-      { data: votesData },
-      { data: participantsData },
-    ] = roundIds.length > 0
-      ? await Promise.all([
-          supabase.from('submissions').select('round_id, user_id').in('round_id', roundIds),
-          supabase.from('votes').select('round_id, voter_user_id').in('round_id', roundIds),
-          supabase.from('round_participants').select('round_id, is_void').in('round_id', roundIds),
-        ])
-      : [{ data: [] }, { data: [] }, { data: [] }];
-
-    const byRound: Record<string, string[]> = {};
-    for (const sub of (subsData ?? [])) {
-      if (!byRound[sub.round_id]) byRound[sub.round_id] = [];
-      if (!byRound[sub.round_id].includes(sub.user_id)) byRound[sub.round_id].push(sub.user_id);
-    }
-    const votersBy: Record<string, string[]> = {};
-    for (const v of (votesData ?? [])) {
-      if (!votersBy[v.round_id]) votersBy[v.round_id] = [];
-      if (!votersBy[v.round_id].includes(v.voter_user_id)) votersBy[v.round_id].push(v.voter_user_id);
-    }
-    const forfeitsBy: Record<string, number> = {};
-    for (const p of (participantsData ?? [])) {
-      if (p.is_void) forfeitsBy[p.round_id] = (forfeitsBy[p.round_id] ?? 0) + 1;
-    }
-    setSubmittersByRound(byRound);
-    setVotersByRound(votersBy);
-    setForfeitsByRound(forfeitsBy);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sr = standingsRes as any;
-    if (sr.error) {
-      console.warn('get_season_standings:', sr.error.message);
-      setStandings([]);
-    } else {
-      setStandings(Array.isArray(sr.data) ? sr.data : []);
-    }
-  }, [seasonId]);
-
   useFocusEffect(
     useCallback(() => {
       refetchSeason();
       refetchRounds();
       refetchMembers();
-      fetchAggregates();
-    }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]),
+      refetchStandings();
+      refetchAggregates();
+    }, [
+      refetchSeason,
+      refetchRounds,
+      refetchMembers,
+      refetchStandings,
+      refetchAggregates,
+    ]),
   );
 
   const [refreshing, setRefreshing] = useState(false);
@@ -486,10 +453,17 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
       refetchSeason(),
       refetchRounds(),
       refetchMembers(),
-      fetchAggregates(),
+      refetchStandings(),
+      refetchAggregates(),
     ]);
     setRefreshing(false);
-  }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]);
+  }, [
+    refetchSeason,
+    refetchRounds,
+    refetchMembers,
+    refetchStandings,
+    refetchAggregates,
+  ]);
 
   const loading = seasonLoading;
 
@@ -498,9 +472,16 @@ export function SeasonScreen({ seasonId, initialTab }: { seasonId: string; initi
       refetchSeason(),
       refetchRounds(),
       refetchMembers(),
-      fetchAggregates(),
+      refetchStandings(),
+      refetchAggregates(),
     ]);
-  }, [refetchSeason, refetchRounds, refetchMembers, fetchAggregates]);
+  }, [
+    refetchSeason,
+    refetchRounds,
+    refetchMembers,
+    refetchStandings,
+    refetchAggregates,
+  ]);
 
   const sortedByRoundNumber = useMemo(
     () => [...rounds].sort((a, b) => a.round_number - b.round_number),

--- a/apps/mobile/src/screens/tabs/MixTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/MixTabScreen.tsx
@@ -1,84 +1,24 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect } from 'expo-router';
-import { supabase } from '@/lib/supabase';
 import { useLeague } from '@/context/LeagueContext';
+import { useActiveRoundForLeague } from '@/queries/useActiveRoundForLeague';
 import { RoundScreen } from '@/screens/round/RoundScreen';
-
-type ActiveRound = {
-  roundId: string;
-  seasonId: string;
-};
-
-type State =
-  | { status: 'loading' }
-  | { status: 'no_league' }
-  | { status: 'no_season' }
-  | { status: 'no_active_round' }
-  | { status: 'ready'; round: ActiveRound };
-
-async function resolveActiveRound(leagueId: string): Promise<{ round: ActiveRound | null; hasActiveSeason: boolean }> {
-  const { data: season } = await supabase
-    .from('seasons')
-    .select('id')
-    .eq('league_id', leagueId)
-    .eq('status', 'active')
-    .single();
-
-  if (!season) return { round: null, hasActiveSeason: false };
-
-  const { data: round } = await supabase
-    .from('rounds')
-    .select('id')
-    .eq('season_id', season.id)
-    .gt('voting_deadline_at', new Date().toISOString())
-    .order('round_number', { ascending: true })
-    .limit(1)
-    .single();
-
-  return {
-    round: round ? { roundId: round.id, seasonId: season.id } : null,
-    hasActiveSeason: true,
-  };
-}
 
 export function MixTabScreen() {
   const { activeLeagueId, activeLeague } = useLeague();
-  const [state, setState] = useState<State>({ status: 'loading' });
+  const { data, isPending, refetch } = useActiveRoundForLeague(
+    activeLeagueId ?? undefined,
+  );
 
-  const resolve = useCallback(async () => {
-    if (!activeLeagueId) {
-      setState({ status: 'no_league' });
-      return;
-    }
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch]),
+  );
 
-    setState({ status: 'loading' });
-    const { round, hasActiveSeason } = await resolveActiveRound(activeLeagueId);
-
-    if (round) {
-      setState({ status: 'ready', round });
-    } else if (hasActiveSeason) {
-      setState({ status: 'no_active_round' });
-    } else {
-      setState({ status: 'no_season' });
-    }
-  }, [activeLeagueId]);
-
-  // Re-resolve when the tab comes into focus (a round may have advanced since last visit)
-  useFocusEffect(useCallback(() => { void resolve(); }, [resolve]));
-
-  if (state.status === 'loading') {
-    return (
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
-        <View style={styles.centered}>
-          <ActivityIndicator color="#555" />
-        </View>
-      </SafeAreaView>
-    );
-  }
-
-  if (state.status === 'no_league') {
+  if (!activeLeagueId) {
     return (
       <SafeAreaView style={styles.safeArea} edges={['top']}>
         <View style={styles.centered}>
@@ -89,7 +29,17 @@ export function MixTabScreen() {
     );
   }
 
-  if (state.status === 'no_season') {
+  if (isPending || !data) {
+    return (
+      <SafeAreaView style={styles.safeArea} edges={['top']}>
+        <View style={styles.centered}>
+          <ActivityIndicator color="#555" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!data.hasActiveSeason) {
     return (
       <SafeAreaView style={styles.safeArea} edges={['top']}>
         <View style={styles.centered}>
@@ -101,7 +51,7 @@ export function MixTabScreen() {
     );
   }
 
-  if (state.status === 'no_active_round') {
+  if (!data.round) {
     return (
       <SafeAreaView style={styles.safeArea} edges={['top']}>
         <View style={styles.centered}>
@@ -115,7 +65,7 @@ export function MixTabScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
-      <RoundScreen roundId={state.round.roundId} seasonId={state.round.seasonId} />
+      <RoundScreen roundId={data.round.roundId} seasonId={data.round.seasonId} />
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePlayback } from '@/playback/PlaybackContext';
 import { useSession } from '@/context/SessionContext';
 import { useLeague } from '@/context/LeagueContext';
-import { supabase } from '@/lib/supabase';
+import { useMyLeagues } from '@/queries/useMyLeagues';
 
 function formatMs(ms: number) {
   const s = Math.floor(ms / 1000);
@@ -150,21 +150,9 @@ export function ProfileTabScreen() {
     next,
     previous,
   } = usePlayback();
-  const { session, signOut } = useSession();
+  const { session, supabaseUserId, signOut } = useSession();
   const { activeLeague, setActiveLeagueId, activeLeagueId } = useLeague();
-  const [leagues, setLeagues] = useState<{ id: string; name: string }[]>([]);
-
-  useEffect(() => {
-    supabase
-      .from('league_members')
-      .select('league:leagues(id, name)')
-      .then(({ data }) => {
-        const flat = (data ?? [])
-          .map((r) => r.league as { id: string; name: string } | null)
-          .filter((l): l is { id: string; name: string } => l !== null);
-        setLeagues(flat);
-      });
-  }, []);
+  const { data: leagues = [] } = useMyLeagues(supabaseUserId ?? undefined);
 
   const handleSwitchLeague = () => {
     if (leagues.length === 0) { Alert.alert('No leagues found'); return; }

--- a/apps/mobile/src/services/auth.ts
+++ b/apps/mobile/src/services/auth.ts
@@ -1,0 +1,49 @@
+import { supabase } from "@/lib/supabase";
+import {
+  loginWithSpotify,
+  getValidAccessToken,
+  clearSpotifySession,
+  getSpotifyProfile,
+} from "@/lib/spotifyAuth";
+import { signInToSupabase } from "@/lib/supabaseAuth";
+import { postgresToMixError, NotAuthenticatedError } from "./errors";
+
+// Triggers the native Spotify OAuth flow, exchanges the token for a Supabase
+// session, and returns the resolved Spotify profile. Throws a NotAuthenticated
+// error if either step fails to produce a session.
+export async function signInWithSpotify(): Promise<void> {
+  await loginWithSpotify();
+  const token = await getValidAccessToken();
+  if (!token) throw new NotAuthenticatedError();
+  await signInToSupabase(token);
+}
+
+export async function signInWithPassword(
+  email: string,
+  password: string,
+): Promise<void> {
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw postgresToMixError(error);
+}
+
+// Tears down both the Spotify session and the Supabase session. Safe to call
+// even if one side was already cleared.
+export async function signOut(): Promise<void> {
+  await Promise.allSettled([clearSpotifySession(), supabase.auth.signOut()]);
+}
+
+export type CurrentUser = {
+  id: string;
+  email: string | null;
+};
+
+export async function getCurrentUser(): Promise<CurrentUser | null> {
+  const { data, error } = await supabase.auth.getUser();
+  if (error) throw postgresToMixError(error);
+  if (!data.user) return null;
+  return { id: data.user.id, email: data.user.email ?? null };
+}
+
+// Re-exported from spotifyAuth for convenience — services-layer consumers
+// shouldn't need to reach into @/lib for platform helpers.
+export { getSpotifyProfile };

--- a/apps/mobile/src/services/commissioner.ts
+++ b/apps/mobile/src/services/commissioner.ts
@@ -1,0 +1,92 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type SeasonUpdate = {
+  name?: string;
+  submissionsPerUser?: number;
+  defaultPointsPerRound?: number;
+  defaultMaxPointsPerTrack?: number;
+};
+
+export type RoundUpdate = {
+  prompt?: string;
+  description?: string;
+  submissionDeadlineAt?: Date | string;
+  votingDeadlineAt?: Date | string;
+};
+
+export type CreateRoundArgs = {
+  seasonId: string;
+  roundNumber: number;
+  prompt: string;
+  description: string;
+  submissionDeadlineAt: Date | string;
+  votingDeadlineAt: Date | string;
+};
+
+function toIso(value: Date | string): string {
+  return typeof value === "string" ? value : value.toISOString();
+}
+
+export async function updateSeason(
+  seasonId: string,
+  patch: SeasonUpdate,
+): Promise<void> {
+  const row: Record<string, unknown> = {};
+  if (patch.name !== undefined) row.name = patch.name;
+  if (patch.submissionsPerUser !== undefined)
+    row.submissions_per_user = patch.submissionsPerUser;
+  if (patch.defaultPointsPerRound !== undefined)
+    row.default_points_per_round = patch.defaultPointsPerRound;
+  if (patch.defaultMaxPointsPerTrack !== undefined)
+    row.default_max_points_per_track = patch.defaultMaxPointsPerTrack;
+
+  const { error } = await supabase
+    .from("seasons")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .update(row as any)
+    .eq("id", seasonId);
+  if (error) throw postgresToMixError(error);
+}
+
+export async function updateRound(
+  roundId: string,
+  patch: RoundUpdate,
+): Promise<void> {
+  const row: Record<string, unknown> = {};
+  if (patch.prompt !== undefined) row.prompt = patch.prompt;
+  if (patch.description !== undefined) row.description = patch.description;
+  if (patch.submissionDeadlineAt !== undefined)
+    row.submission_deadline_at = toIso(patch.submissionDeadlineAt);
+  if (patch.votingDeadlineAt !== undefined)
+    row.voting_deadline_at = toIso(patch.votingDeadlineAt);
+
+  const { error } = await supabase
+    .from("rounds")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .update(row as any)
+    .eq("id", roundId);
+  if (error) throw postgresToMixError(error);
+}
+
+export async function createRound(args: CreateRoundArgs): Promise<void> {
+  const { error } = await supabase.from("rounds").insert({
+    season_id: args.seasonId,
+    round_number: args.roundNumber,
+    prompt: args.prompt,
+    description: args.description,
+    submission_deadline_at: toIso(args.submissionDeadlineAt),
+    voting_deadline_at: toIso(args.votingDeadlineAt),
+  });
+  if (error) throw postgresToMixError(error);
+}
+
+// Sets voting_deadline_at = now() so getPhase() flips the round to results
+// immediately. DB triggers pick up forfeits + playlist positions.
+export async function forceEndRound(roundId: string): Promise<void> {
+  const { error } = await supabase
+    .from("rounds")
+    .update({ voting_deadline_at: new Date().toISOString() })
+    .eq("id", roundId);
+  if (error) throw postgresToMixError(error);
+}

--- a/apps/mobile/src/services/errors.ts
+++ b/apps/mobile/src/services/errors.ts
@@ -1,0 +1,59 @@
+// Typed error taxonomy for the services layer. Services throw these; clients
+// catch on the concrete class (e.g. `if (err instanceof VoteBudgetError) …`).
+//
+// The Postgres RPCs use RAISE EXCEPTION with human-readable messages and no
+// custom SQLSTATE, so the mapper matches on message text. If/when we add
+// SQLSTATE codes to the RPCs, switch the mapper to use those.
+
+export class MixError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = this.constructor.name;
+  }
+}
+
+export class UnknownMixError extends MixError {}
+
+export class RoundNotFoundError extends MixError {
+  constructor(cause?: unknown) {
+    super("Round not found.", { cause });
+  }
+}
+
+export class NotEligibleToVoteError extends MixError {
+  constructor(cause?: unknown) {
+    super("You didn't submit a track this round, so you can't vote.", { cause });
+  }
+}
+
+export class AlreadyVotedError extends MixError {
+  constructor(cause?: unknown) {
+    super("You've already voted in this round.", { cause });
+  }
+}
+
+export class VoteBudgetError extends MixError {
+  required: number;
+  provided: number;
+  constructor(required: number, provided: number, cause?: unknown) {
+    super(`You must spend all ${required} points (submitted ${provided}).`, { cause });
+    this.required = required;
+    this.provided = provided;
+  }
+}
+
+export function postgresToMixError(err: { message?: string | null } | null | undefined): MixError {
+  const msg = err?.message ?? "";
+  if (!msg) return new UnknownMixError("Unknown error.", { cause: err });
+
+  if (msg === "Round not found") return new RoundNotFoundError(err);
+  if (msg.includes("not eligible to vote")) return new NotEligibleToVoteError(err);
+  if (msg.includes("already voted in this round")) return new AlreadyVotedError(err);
+
+  const budgetMatch = msg.match(/spend all (\d+) points \(submitted (\d+)\)/);
+  if (budgetMatch) {
+    return new VoteBudgetError(Number(budgetMatch[1]), Number(budgetMatch[2]), err);
+  }
+
+  return new UnknownMixError(msg, { cause: err });
+}

--- a/apps/mobile/src/services/errors.ts
+++ b/apps/mobile/src/services/errors.ts
@@ -1,9 +1,9 @@
 // Typed error taxonomy for the services layer. Services throw these; clients
 // catch on the concrete class (e.g. `if (err instanceof VoteBudgetError) …`).
 //
-// The Postgres RPCs use RAISE EXCEPTION with human-readable messages and no
-// custom SQLSTATE, so the mapper matches on message text. If/when we add
-// SQLSTATE codes to the RPCs, switch the mapper to use those.
+// The Postgres RPCs/triggers use RAISE EXCEPTION with human-readable messages
+// and no custom SQLSTATE, so the mapper matches on message text. If/when we
+// add SQLSTATE codes, switch the mapper to use those.
 
 export class MixError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
@@ -19,6 +19,8 @@ export class RoundNotFoundError extends MixError {
     super("Round not found.", { cause });
   }
 }
+
+// ─── Vote errors ──────────────────────────────────────────────────────────────
 
 export class NotEligibleToVoteError extends MixError {
   constructor(cause?: unknown) {
@@ -42,18 +44,83 @@ export class VoteBudgetError extends MixError {
   }
 }
 
+// ─── Submission errors ────────────────────────────────────────────────────────
+
+export class DeadlinePassedError extends MixError {
+  constructor(cause?: unknown) {
+    super("The submission deadline for this round has passed.", { cause });
+  }
+}
+
+export class MaxSubmissionsReachedError extends MixError {
+  existing: number;
+  allowed: number;
+  constructor(existing: number, allowed: number, cause?: unknown) {
+    super(
+      `You've reached the submission limit for this round (${existing} of ${allowed}).`,
+      { cause },
+    );
+    this.existing = existing;
+    this.allowed = allowed;
+  }
+}
+
+export class PreviousRoundInProgressError extends MixError {
+  constructor(cause?: unknown) {
+    super("The previous round is still in progress.", { cause });
+  }
+}
+
+export class SpectatorCannotSubmitError extends MixError {
+  constructor(cause?: unknown) {
+    super("Spectators can't submit tracks.", { cause });
+  }
+}
+
+export class NotLeagueMemberError extends MixError {
+  constructor(cause?: unknown) {
+    super("You're not a member of this league.", { cause });
+  }
+}
+
+// ─── Auth / generic ───────────────────────────────────────────────────────────
+
+export class NotAuthenticatedError extends MixError {
+  constructor(cause?: unknown) {
+    super("You're not signed in.", { cause });
+  }
+}
+
+// ─── Mapper ───────────────────────────────────────────────────────────────────
+
 export function postgresToMixError(err: { message?: string | null } | null | undefined): MixError {
   const msg = err?.message ?? "";
   if (!msg) return new UnknownMixError("Unknown error.", { cause: err });
 
+  // Round-level
   if (msg === "Round not found") return new RoundNotFoundError(err);
+
+  // Vote
   if (msg.includes("not eligible to vote")) return new NotEligibleToVoteError(err);
   if (msg.includes("already voted in this round")) return new AlreadyVotedError(err);
-
   const budgetMatch = msg.match(/spend all (\d+) points \(submitted (\d+)\)/);
   if (budgetMatch) {
     return new VoteBudgetError(Number(budgetMatch[1]), Number(budgetMatch[2]), err);
   }
+
+  // Submission
+  if (msg.includes("Submission deadline has passed")) return new DeadlinePassedError(err);
+  const maxSubsMatch = msg.match(/maximum number of tracks for this round \((\d+) of (\d+)\)/);
+  if (maxSubsMatch) {
+    return new MaxSubmissionsReachedError(
+      Number(maxSubsMatch[1]),
+      Number(maxSubsMatch[2]),
+      err,
+    );
+  }
+  if (msg.includes("Previous round is still in progress")) return new PreviousRoundInProgressError(err);
+  if (msg.includes("Spectators cannot submit")) return new SpectatorCannotSubmitError(err);
+  if (msg.includes("not a member of this league")) return new NotLeagueMemberError(err);
 
   return new UnknownMixError(msg, { cause: err });
 }

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -2,3 +2,6 @@ export * from "./errors";
 export * from "./votes";
 export * from "./submissions";
 export * from "./spotifySearch";
+export * from "./rounds";
+export * from "./seasons";
+export * from "./leagues";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -1,2 +1,4 @@
 export * from "./errors";
 export * from "./votes";
+export * from "./submissions";
+export * from "./spotifySearch";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -7,3 +7,4 @@ export * from "./seasons";
 export * from "./leagues";
 export * from "./results";
 export * from "./standings";
+export * from "./commissioner";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from "./errors";
+export * from "./votes";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -9,3 +9,5 @@ export * from "./results";
 export * from "./standings";
 export * from "./commissioner";
 export * from "./invites";
+export * from "./auth";
+export * from "./users";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -5,3 +5,5 @@ export * from "./spotifySearch";
 export * from "./rounds";
 export * from "./seasons";
 export * from "./leagues";
+export * from "./results";
+export * from "./standings";

--- a/apps/mobile/src/services/index.ts
+++ b/apps/mobile/src/services/index.ts
@@ -8,3 +8,4 @@ export * from "./leagues";
 export * from "./results";
 export * from "./standings";
 export * from "./commissioner";
+export * from "./invites";

--- a/apps/mobile/src/services/invites.ts
+++ b/apps/mobile/src/services/invites.ts
@@ -1,0 +1,56 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type JoinInviteInfo = {
+  seasonId: string;
+  seasonName: string;
+  seasonStatus: string;
+  leagueId: string;
+  leagueName: string;
+};
+
+type JoinInviteRpcRow = {
+  season_id: string;
+  season_name: string;
+  season_status: string;
+  league_id: string;
+  league_name: string;
+};
+
+// Looks up a season + league by invite token via the get_join_invite_info RPC.
+// Returns null if the token is invalid / not found.
+export async function getJoinInviteInfo(
+  token: string,
+): Promise<JoinInviteInfo | null> {
+  const { data, error } = await supabase
+    // RPC name isn't in the generated types; cast until regenerated.
+    .rpc("get_join_invite_info" as never, { invite_token: token } as never)
+    .single();
+  if (error) {
+    // No rows / bad token → return null, don't throw
+    if (error.code === "PGRST116") return null;
+    throw postgresToMixError(error);
+  }
+  const row = data as JoinInviteRpcRow | null;
+  if (!row) return null;
+  return {
+    seasonId: row.season_id,
+    seasonName: row.season_name,
+    seasonStatus: row.season_status,
+    leagueId: row.league_id,
+    leagueName: row.league_name,
+  };
+}
+
+// Adds the user to a league via membership insert. The inviting season isn't
+// referenced here because membership is league-scoped.
+export async function joinLeagueViaInvite(args: {
+  leagueId: string;
+  userId: string;
+  role: "participant" | "spectator";
+}): Promise<void> {
+  const { error } = await supabase
+    .from("league_members")
+    .insert({ league_id: args.leagueId, user_id: args.userId, role: args.role });
+  if (error) throw postgresToMixError(error);
+}

--- a/apps/mobile/src/services/leagues.ts
+++ b/apps/mobile/src/services/leagues.ts
@@ -80,3 +80,50 @@ export async function getFirstLeagueIdForUser(
   if (error) throw postgresToMixError(error);
   return data?.league_id ?? null;
 }
+
+export type MasterPlaylistMode = "fresh" | "cloned" | "linked";
+
+export type CreateLeagueArgs = {
+  name: string;
+  masterPlaylistMode?: MasterPlaylistMode;
+  masterPlaylistRef?: string | null;
+};
+
+// Creates a league via the create_league RPC (atomic: inserts league +
+// commissioner membership). Optionally patches playlist mode/ref. Returns
+// the new league id.
+export async function createLeague(args: CreateLeagueArgs): Promise<string> {
+  const { data: leagueId, error } = await supabase.rpc("create_league", {
+    league_name: args.name,
+  });
+  if (error) throw postgresToMixError(error);
+  if (!leagueId) throw new Error("create_league returned no id");
+
+  if (args.masterPlaylistMode && args.masterPlaylistMode !== "fresh") {
+    const { error: updateErr } = await supabase
+      .from("leagues")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .update({
+        master_playlist_mode: args.masterPlaylistMode,
+        master_playlist_ref: args.masterPlaylistRef ?? null,
+      } as any)
+      .eq("id", leagueId as string);
+    if (updateErr) throw postgresToMixError(updateErr);
+  }
+
+  return leagueId as string;
+}
+
+export async function isLeagueMember(
+  leagueId: string,
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("league_members")
+    .select("user_id")
+    .eq("league_id", leagueId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return data !== null;
+}

--- a/apps/mobile/src/services/leagues.ts
+++ b/apps/mobile/src/services/leagues.ts
@@ -1,0 +1,82 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type League = {
+  id: string;
+  name: string;
+  admin_user_id: string;
+};
+
+export type LeagueMember = {
+  user_id: string;
+  role: "participant" | "spectator";
+  display_name: string;
+};
+
+export type LeagueSummary = {
+  id: string;
+  name: string;
+};
+
+export async function getLeague(leagueId: string): Promise<League | null> {
+  const { data, error } = await supabase
+    .from("leagues")
+    .select("id, name, admin_user_id")
+    .eq("id", leagueId)
+    .single();
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw postgresToMixError(error);
+  }
+  return data;
+}
+
+export async function getLeagueMembers(
+  leagueId: string,
+): Promise<LeagueMember[]> {
+  const { data, error } = await supabase
+    .from("league_members")
+    .select("user_id, role, users(display_name)")
+    .eq("league_id", leagueId)
+    .order("joined_at", { ascending: true });
+  if (error) throw postgresToMixError(error);
+  return (data ?? []).map((row) => {
+    const user = Array.isArray(row.users) ? row.users[0] : row.users;
+    return {
+      user_id: row.user_id,
+      role: row.role as LeagueMember["role"],
+      display_name: user?.display_name ?? "",
+    };
+  });
+}
+
+// Returns the caller's role in this league, or null if they're not a member.
+export async function getMyRole(
+  leagueId: string,
+  userId: string,
+): Promise<LeagueMember["role"] | null> {
+  const { data, error } = await supabase
+    .from("league_members")
+    .select("role")
+    .eq("league_id", leagueId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return (data?.role as LeagueMember["role"] | undefined) ?? null;
+}
+
+// The first league the user joined. Used by LeagueContext to pick a default
+// active league on login.
+export async function getFirstLeagueIdForUser(
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("league_members")
+    .select("league_id")
+    .eq("user_id", userId)
+    .order("joined_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return data?.league_id ?? null;
+}

--- a/apps/mobile/src/services/results.ts
+++ b/apps/mobile/src/services/results.ts
@@ -1,0 +1,76 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type RoundResult = {
+  submission_id: string;
+  user_id: string;
+  display_name: string;
+  track_title: string;
+  track_artist: string;
+  track_artwork_url: string | null;
+  spotify_track_id: string | null;
+  track_isrc: string;
+  points_raw: number;
+  points_effective: number;
+  is_void: boolean;
+};
+
+export type VoterEntry = {
+  voter_user_id: string;
+  voter_name: string;
+  points: number;
+  comment: string | null;
+};
+
+export async function getRoundResults(roundId: string): Promise<RoundResult[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.rpc as any)("get_round_results", {
+    p_round_id: roundId,
+  });
+  if (error) throw postgresToMixError(error);
+  return (data ?? []) as RoundResult[];
+}
+
+// Fetches votes (with voter display names) + per-voter comments, grouped by
+// submission and sorted by points desc. This is the shape ResultsPhase needs.
+export async function getRoundVotersBySubmission(
+  roundId: string,
+): Promise<Record<string, VoterEntry[]>> {
+  const [votesRes, commentsRes] = await Promise.all([
+    supabase
+      .from("votes")
+      .select("submission_id, points, voter_user_id, users(display_name)")
+      .eq("round_id", roundId),
+    supabase
+      .from("comments")
+      .select("submission_id, body, author_user_id")
+      .eq("round_id", roundId),
+  ]);
+  if (votesRes.error) throw postgresToMixError(votesRes.error);
+  if (commentsRes.error) throw postgresToMixError(commentsRes.error);
+
+  const commentLookup: Record<string, Record<string, string>> = {};
+  for (const c of commentsRes.data ?? []) {
+    if (!commentLookup[c.submission_id]) commentLookup[c.submission_id] = {};
+    commentLookup[c.submission_id][c.author_user_id] = c.body;
+  }
+
+  const voterMap: Record<string, VoterEntry[]> = {};
+  for (const v of votesRes.data ?? []) {
+    if (!voterMap[v.submission_id]) voterMap[v.submission_id] = [];
+    const users = v.users as { display_name: string } | { display_name: string }[] | null;
+    const name =
+      (Array.isArray(users) ? users[0]?.display_name : users?.display_name) ??
+      "Unknown";
+    voterMap[v.submission_id].push({
+      voter_user_id: v.voter_user_id,
+      voter_name: name,
+      points: v.points,
+      comment: commentLookup[v.submission_id]?.[v.voter_user_id] ?? null,
+    });
+  }
+  for (const entries of Object.values(voterMap)) {
+    entries.sort((a, b) => b.points - a.points);
+  }
+  return voterMap;
+}

--- a/apps/mobile/src/services/rounds.ts
+++ b/apps/mobile/src/services/rounds.ts
@@ -98,3 +98,41 @@ export async function getRoundCountForSeason(seasonId: string): Promise<number> 
   if (error) throw postgresToMixError(error);
   return count ?? 0;
 }
+
+export type ActiveRoundLookup = {
+  round: { roundId: string; seasonId: string } | null;
+  hasActiveSeason: boolean;
+};
+
+// Finds the currently-open round for a league — earliest round whose voting
+// deadline hasn't passed, within the league's active season. Returns a
+// discriminated shape so callers can distinguish "no active season" from
+// "active season but all rounds closed" without extra lookups.
+export async function getActiveRoundForLeague(
+  leagueId: string,
+): Promise<ActiveRoundLookup> {
+  const { data: season, error: seasonErr } = await supabase
+    .from("seasons")
+    .select("id")
+    .eq("league_id", leagueId)
+    .eq("status", "active")
+    .limit(1)
+    .maybeSingle();
+  if (seasonErr) throw postgresToMixError(seasonErr);
+  if (!season) return { round: null, hasActiveSeason: false };
+
+  const { data: round, error: roundErr } = await supabase
+    .from("rounds")
+    .select("id")
+    .eq("season_id", season.id)
+    .gt("voting_deadline_at", new Date().toISOString())
+    .order("round_number", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (roundErr) throw postgresToMixError(roundErr);
+
+  return {
+    round: round ? { roundId: round.id, seasonId: season.id } : null,
+    hasActiveSeason: true,
+  };
+}

--- a/apps/mobile/src/services/rounds.ts
+++ b/apps/mobile/src/services/rounds.ts
@@ -1,0 +1,100 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type Round = {
+  id: string;
+  round_number: number;
+  prompt: string;
+  description: string;
+  submission_deadline_at: string;
+  voting_deadline_at: string;
+  season_id: string;
+  seasons: {
+    id: string;
+    name: string;
+    status: string;
+    submissions_per_user: number;
+    default_points_per_round: number;
+    default_max_points_per_track: number;
+    league_id: string;
+  } | null;
+};
+
+export type SiblingRound = {
+  id: string;
+  round_number: number;
+  prompt: string;
+  voting_deadline_at: string;
+};
+
+export type RoundListItem = {
+  id: string;
+  round_number: number;
+  prompt: string;
+  description: string;
+  submission_deadline_at: string;
+  voting_deadline_at: string;
+};
+
+const ROUND_SELECT =
+  "id, round_number, prompt, description, submission_deadline_at, voting_deadline_at, season_id, seasons(id, name, status, submissions_per_user, default_points_per_round, default_max_points_per_track, league_id)";
+
+export async function getRound(roundId: string): Promise<Round | null> {
+  const { data, error } = await supabase
+    .from("rounds")
+    .select(ROUND_SELECT)
+    .eq("id", roundId)
+    .single();
+  if (error) {
+    if (error.code === "PGRST116") return null; // no rows
+    throw postgresToMixError(error);
+  }
+  if (!data) return null;
+
+  // The TS type for nested single-row joins via supabase-js comes through as
+  // an array in some schema versions; normalize to a single object for the
+  // domain shape.
+  const season = Array.isArray(data.seasons) ? data.seasons[0] : data.seasons;
+  return { ...data, seasons: season ?? null };
+}
+
+export async function getPreviousRound(
+  seasonId: string,
+  currentRoundNumber: number,
+): Promise<SiblingRound | null> {
+  if (currentRoundNumber <= 1) return null;
+  const { data, error } = await supabase
+    .from("rounds")
+    .select("id, round_number, prompt, voting_deadline_at")
+    .eq("season_id", seasonId)
+    .eq("round_number", currentRoundNumber - 1)
+    .single();
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw postgresToMixError(error);
+  }
+  return data;
+}
+
+export async function getRoundsForSeason(
+  seasonId: string,
+): Promise<RoundListItem[]> {
+  const { data, error } = await supabase
+    .from("rounds")
+    .select(
+      "id, round_number, prompt, description, submission_deadline_at, voting_deadline_at",
+    )
+    .eq("season_id", seasonId)
+    .order("round_number", { ascending: true });
+  if (error) throw postgresToMixError(error);
+  return data ?? [];
+}
+
+export async function getRoundCountForSeason(seasonId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from("rounds")
+    .select("id", { count: "exact", head: true })
+    .eq("season_id", seasonId);
+  if (error) throw postgresToMixError(error);
+  return count ?? 0;
+}

--- a/apps/mobile/src/services/seasons.ts
+++ b/apps/mobile/src/services/seasons.ts
@@ -1,0 +1,80 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type SeasonStatus = "draft" | "active" | "completed";
+
+export type Season = {
+  id: string;
+  name: string;
+  season_number: number;
+  status: string;
+  league_id: string;
+  submissions_per_user: number;
+  default_points_per_round: number;
+  default_max_points_per_track: number;
+  leagues: {
+    id: string;
+    name: string;
+    admin_user_id: string;
+  } | null;
+};
+
+export type SeasonListItem = {
+  id: string;
+  name: string;
+  season_number: number;
+  status: string;
+  invite_token: string | null;
+};
+
+// Stale DB types (packages/db/types.ts) miss submissions_per_user on seasons,
+// so supabase-js's select-parser rejects this select. Cast through unknown
+// until types are regenerated.
+const SEASON_SELECT =
+  "id, name, season_number, status, league_id, submissions_per_user, default_points_per_round, default_max_points_per_track, leagues(id, name, admin_user_id)";
+
+type SeasonRow = Omit<Season, "leagues"> & {
+  leagues: Season["leagues"] | Season["leagues"][];
+};
+
+export async function getSeason(seasonId: string): Promise<Season | null> {
+  const { data, error } = await supabase
+    .from("seasons")
+    .select(SEASON_SELECT as string)
+    .eq("id", seasonId)
+    .single();
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw postgresToMixError(error);
+  }
+  if (!data) return null;
+  const row = data as unknown as SeasonRow;
+  const league = Array.isArray(row.leagues) ? row.leagues[0] : row.leagues;
+  return { ...row, leagues: league ?? null };
+}
+
+export async function getSeasonsForLeague(
+  leagueId: string,
+): Promise<SeasonListItem[]> {
+  const { data, error } = await supabase
+    .from("seasons")
+    .select("id, name, season_number, status, invite_token")
+    .eq("league_id", leagueId)
+    .order("season_number", { ascending: false });
+  if (error) throw postgresToMixError(error);
+  return data ?? [];
+}
+
+export async function getActiveSeasonForLeague(
+  leagueId: string,
+): Promise<{ id: string } | null> {
+  const { data, error } = await supabase
+    .from("seasons")
+    .select("id")
+    .eq("league_id", leagueId)
+    .eq("status", "active")
+    .limit(1)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return data;
+}

--- a/apps/mobile/src/services/seasons.ts
+++ b/apps/mobile/src/services/seasons.ts
@@ -78,3 +78,100 @@ export async function getActiveSeasonForLeague(
   if (error) throw postgresToMixError(error);
   return data;
 }
+
+// UX pre-flight: is any round in this league still in progress (voting hasn't
+// closed). Used to show a friendly message before trying to create a new
+// season. The DB still rejects independently — this is purely for the nice
+// error path.
+export async function hasInProgressSeason(leagueId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("rounds")
+    .select("id, seasons!inner(league_id)")
+    .gt("voting_deadline_at", new Date().toISOString())
+    .eq("seasons.league_id", leagueId);
+  if (error) throw postgresToMixError(error);
+  return (data ?? []).length > 0;
+}
+
+export type CreateSeasonRoundInput = {
+  prompt: string;
+  description: string;
+  submissionDeadlineAt: Date | string;
+  votingDeadlineAt: Date | string;
+};
+
+export type CreateSeasonArgs = {
+  leagueId: string;
+  name: string;
+  participantCap?: number | null;
+  submissionsPerUser: number;
+  defaultPointsPerRound: number;
+  defaultMaxPointsPerTrack: number;
+  rounds: CreateSeasonRoundInput[];
+};
+
+function toIso(value: Date | string): string {
+  return typeof value === "string" ? value : value.toISOString();
+}
+
+// Creates a season + its rounds. Season number is derived from the existing
+// count for the league. Not transactional across the two inserts — in
+// practice this is commissioner-only and low-volume, but the DB guard on
+// in-progress seasons still protects against duplicate season creation.
+export async function createSeason(
+  args: CreateSeasonArgs,
+): Promise<{ seasonId: string }> {
+  const { count, error: countErr } = await supabase
+    .from("seasons")
+    .select("id", { count: "exact", head: true })
+    .eq("league_id", args.leagueId);
+  if (countErr) throw postgresToMixError(countErr);
+
+  const { data: seasonData, error: seasonErr } = await supabase
+    .from("seasons")
+    .insert({
+      league_id: args.leagueId,
+      name: args.name,
+      season_number: (count ?? 0) + 1,
+      participant_cap: args.participantCap ?? null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      submissions_per_user: args.submissionsPerUser,
+      default_points_per_round: args.defaultPointsPerRound,
+      default_max_points_per_track: args.defaultMaxPointsPerTrack,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+    .select("id")
+    .single();
+  if (seasonErr) throw postgresToMixError(seasonErr);
+  if (!seasonData?.id) throw new Error("Season insert returned no id");
+
+  const { error: roundsErr } = await supabase.from("rounds").insert(
+    args.rounds.map((r, i) => ({
+      season_id: seasonData.id,
+      round_number: i + 1,
+      prompt: r.prompt,
+      description: r.description,
+      submission_deadline_at: toIso(r.submissionDeadlineAt),
+      voting_deadline_at: toIso(r.votingDeadlineAt),
+    })),
+  );
+  if (roundsErr) throw postgresToMixError(roundsErr);
+
+  return { seasonId: seasonData.id };
+}
+
+export async function getSeasonInviteToken(
+  seasonId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("seasons")
+    .select("invite_token")
+    .eq("id", seasonId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return data?.invite_token ?? null;
+}
+
+export function buildInviteLink(token: string): string {
+  return `mix://join?token=${token}`;
+}

--- a/apps/mobile/src/services/spotifySearch.ts
+++ b/apps/mobile/src/services/spotifySearch.ts
@@ -1,0 +1,46 @@
+import { getValidAccessToken } from "@/lib/spotifyAuth";
+import { NotAuthenticatedError, UnknownMixError } from "./errors";
+
+export type SpotifyTrack = {
+  id: string;
+  name: string;
+  artists: { name: string }[];
+  album: { name: string; images: { url: string }[] };
+  duration_ms: number;
+  external_ids: { isrc?: string };
+  popularity: number;
+};
+
+// Pulls the track id out of a Spotify URL or URI. Returns null if the input
+// isn't recognizable as a track reference — caller falls back to text search.
+export function extractSpotifyTrackId(input: string): string | null {
+  const urlMatch = input.match(/spotify\.com\/track\/([a-zA-Z0-9]+)/);
+  if (urlMatch) return urlMatch[1];
+  const uriMatch = input.match(/spotify:track:([a-zA-Z0-9]+)/);
+  if (uriMatch) return uriMatch[1];
+  return null;
+}
+
+async function authedFetch(url: string): Promise<Response> {
+  const token = await getValidAccessToken();
+  if (!token) throw new NotAuthenticatedError();
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  return res;
+}
+
+export async function searchSpotifyTracks(query: string): Promise<SpotifyTrack[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const res = await authedFetch(
+    `https://api.spotify.com/v1/search?q=${encodeURIComponent(trimmed)}&type=track&limit=8`,
+  );
+  if (!res.ok) throw new UnknownMixError(`Spotify search failed (${res.status})`);
+  const data = (await res.json()) as { tracks?: { items: SpotifyTrack[] } };
+  return data.tracks?.items ?? [];
+}
+
+export async function getSpotifyTrack(trackId: string): Promise<SpotifyTrack> {
+  const res = await authedFetch(`https://api.spotify.com/v1/tracks/${trackId}`);
+  if (!res.ok) throw new UnknownMixError(`Spotify lookup failed (${res.status})`);
+  return (await res.json()) as SpotifyTrack;
+}

--- a/apps/mobile/src/services/standings.ts
+++ b/apps/mobile/src/services/standings.ts
@@ -1,0 +1,89 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type SeasonStanding = {
+  user_id: string;
+  display_name: string;
+  total_points: number;
+  rounds_played: number;
+  rounds_forfeited: number;
+  member_role: "participant" | "spectator";
+};
+
+export type SeasonAggregates = {
+  // Map of roundId -> distinct user_ids who submitted at least once.
+  submittersByRound: Record<string, string[]>;
+  // Map of roundId -> distinct voter_user_ids who cast a vote.
+  votersByRound: Record<string, string[]>;
+  // Map of roundId -> count of round_participants flagged is_void.
+  forfeitsByRound: Record<string, number>;
+};
+
+export async function getSeasonStandings(
+  seasonId: string,
+): Promise<SeasonStanding[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase.rpc as any)("get_season_standings", {
+    p_season_id: seasonId,
+  });
+  if (error) throw postgresToMixError(error);
+  return (data ?? []) as SeasonStanding[];
+}
+
+// Per-round counts of submitters / voters / forfeits across a season, used by
+// SeasonScreen's round cards. Fetched in a single trip for all rounds in the
+// season.
+export async function getSeasonAggregates(
+  seasonId: string,
+): Promise<SeasonAggregates> {
+  const { data: roundsData, error: roundsErr } = await supabase
+    .from("rounds")
+    .select("id")
+    .eq("season_id", seasonId);
+  if (roundsErr) throw postgresToMixError(roundsErr);
+
+  const roundIds = (roundsData ?? []).map((r) => r.id);
+  if (roundIds.length === 0) {
+    return { submittersByRound: {}, votersByRound: {}, forfeitsByRound: {} };
+  }
+
+  const [subsRes, votesRes, participantsRes] = await Promise.all([
+    supabase
+      .from("submissions")
+      .select("round_id, user_id")
+      .in("round_id", roundIds),
+    supabase
+      .from("votes")
+      .select("round_id, voter_user_id")
+      .in("round_id", roundIds),
+    supabase
+      .from("round_participants")
+      .select("round_id, is_void")
+      .in("round_id", roundIds),
+  ]);
+  if (subsRes.error) throw postgresToMixError(subsRes.error);
+  if (votesRes.error) throw postgresToMixError(votesRes.error);
+  if (participantsRes.error) throw postgresToMixError(participantsRes.error);
+
+  const submittersByRound: Record<string, string[]> = {};
+  for (const s of subsRes.data ?? []) {
+    if (!submittersByRound[s.round_id]) submittersByRound[s.round_id] = [];
+    if (!submittersByRound[s.round_id].includes(s.user_id))
+      submittersByRound[s.round_id].push(s.user_id);
+  }
+
+  const votersByRound: Record<string, string[]> = {};
+  for (const v of votesRes.data ?? []) {
+    if (!votersByRound[v.round_id]) votersByRound[v.round_id] = [];
+    if (!votersByRound[v.round_id].includes(v.voter_user_id))
+      votersByRound[v.round_id].push(v.voter_user_id);
+  }
+
+  const forfeitsByRound: Record<string, number> = {};
+  for (const p of participantsRes.data ?? []) {
+    if (p.is_void)
+      forfeitsByRound[p.round_id] = (forfeitsByRound[p.round_id] ?? 0) + 1;
+  }
+
+  return { submittersByRound, votersByRound, forfeitsByRound };
+}

--- a/apps/mobile/src/services/submissions.ts
+++ b/apps/mobile/src/services/submissions.ts
@@ -1,0 +1,75 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+// Shape passed by the UI for each track slot. Maps to columns in `submissions`.
+export type TrackSelection = {
+  spotifyTrackId: string;
+  title: string;
+  artist: string;
+  artworkUrl: string | null;
+  isrc: string | null;
+  albumName: string | null;
+  durationMs: number | null;
+  popularity: number | null;
+};
+
+// One per slot. submissionId = null means "insert new"; otherwise "update".
+export type SubmissionDraft = {
+  submissionId: string | null;
+  track: TrackSelection;
+  comment: string;
+};
+
+export type SubmitRoundEntriesArgs = {
+  roundId: string;
+  userId: string;
+  drafts: SubmissionDraft[];
+};
+
+function draftToColumns(draft: SubmissionDraft) {
+  const { track } = draft;
+  return {
+    spotify_track_id: track.spotifyTrackId,
+    track_title: track.title,
+    track_artist: track.artist,
+    track_artwork_url: track.artworkUrl,
+    track_isrc: track.isrc ?? "",
+    track_album_name: track.albumName,
+    track_duration_ms: track.durationMs,
+    track_popularity: track.popularity,
+    comment: draft.comment.trim() || null,
+  };
+}
+
+// Applies a user's full draft set to a round: updates for drafts with an
+// existing submissionId, inserts for drafts without one. Runs updates first
+// so inserts only fire after existing slots are consistent. DB-side triggers
+// enforce deadline / quota / spectator rules; mapped to typed errors.
+export async function submitRoundEntries(
+  args: SubmitRoundEntriesArgs,
+): Promise<void> {
+  const updates = args.drafts.filter((d) => d.submissionId);
+  const inserts = args.drafts.filter((d) => !d.submissionId);
+
+  const updateResults = await Promise.all(
+    updates.map((d) =>
+      supabase
+        .from("submissions")
+        .update(draftToColumns(d))
+        .eq("id", d.submissionId!)
+        .eq("user_id", args.userId),
+    ),
+  );
+  const updateErr = updateResults.find((r) => r.error)?.error;
+  if (updateErr) throw postgresToMixError(updateErr);
+
+  if (inserts.length > 0) {
+    const rows = inserts.map((d) => ({
+      round_id: args.roundId,
+      user_id: args.userId,
+      ...draftToColumns(d),
+    }));
+    const { error } = await supabase.from("submissions").insert(rows);
+    if (error) throw postgresToMixError(error);
+  }
+}

--- a/apps/mobile/src/services/users.ts
+++ b/apps/mobile/src/services/users.ts
@@ -1,0 +1,46 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type UserLeagueSummary = {
+  id: string;
+  name: string;
+};
+
+export async function getUserDisplayName(
+  userId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("users")
+    .select("display_name")
+    .eq("id", userId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return data?.display_name ?? null;
+}
+
+export async function getMyLeagues(): Promise<UserLeagueSummary[]> {
+  // league_members is already RLS-scoped to the current user, so no explicit
+  // user_id filter is needed here.
+  const { data, error } = await supabase
+    .from("league_members")
+    .select("league:leagues(id, name)");
+  if (error) throw postgresToMixError(error);
+  return (data ?? [])
+    .map((r) => r.league as UserLeagueSummary | null)
+    .filter((l): l is UserLeagueSummary => l !== null);
+}
+
+export async function updateProfile(
+  userId: string,
+  patch: { displayName?: string },
+): Promise<void> {
+  const row: Record<string, unknown> = {};
+  if (patch.displayName !== undefined) row.display_name = patch.displayName;
+  if (Object.keys(row).length === 0) return;
+  const { error } = await supabase
+    .from("users")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .update(row as any)
+    .eq("id", userId);
+  if (error) throw postgresToMixError(error);
+}

--- a/apps/mobile/src/services/votes.ts
+++ b/apps/mobile/src/services/votes.ts
@@ -1,0 +1,95 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError, UnknownMixError } from "./errors";
+
+// The voter's view of a submission. Intentionally narrower than the full row —
+// results phase reads more columns via its own service when we get there.
+export type VotingSubmission = {
+  id: string;
+  user_id: string;
+  track_title: string;
+  track_artist: string;
+  track_artwork_url: string | null;
+  spotify_track_id: string | null;
+  track_isrc: string;
+  comment: string | null;
+};
+
+export type VoteInput = { submissionId: string; points: number };
+export type VoteCommentInput = { submissionId: string; body: string };
+
+export type SubmitVotesArgs = {
+  roundId: string;
+  userId: string;
+  votes: VoteInput[];
+  comments?: VoteCommentInput[];
+};
+
+export async function getRoundSubmissions(
+  roundId: string,
+): Promise<VotingSubmission[]> {
+  const { data, error } = await supabase
+    .from("submissions")
+    .select(
+      "id, user_id, track_title, track_artist, track_artwork_url, spotify_track_id, track_isrc, comment",
+    )
+    .eq("round_id", roundId);
+  if (error) throw postgresToMixError(error);
+  return data ?? [];
+}
+
+// Map of submissionId -> points the voter already allocated. Empty object if
+// they haven't voted yet.
+export async function getMyVotes(
+  roundId: string,
+  userId: string,
+): Promise<Record<string, number>> {
+  const { data, error } = await supabase
+    .from("votes")
+    .select("submission_id, points")
+    .eq("round_id", roundId)
+    .eq("voter_user_id", userId);
+  if (error) throw postgresToMixError(error);
+  const map: Record<string, number> = {};
+  for (const row of data ?? []) {
+    map[row.submission_id] = row.points;
+  }
+  return map;
+}
+
+// Submit votes + optional per-submission comments. The RPC is atomic; comments
+// are a separate insert that runs only if the RPC succeeded. If comments fail
+// after votes land, the votes still persist and we surface an UnknownMixError.
+// Wrapping both in a single DB function is a worthwhile follow-up.
+export async function submitVotes(args: SubmitVotesArgs): Promise<void> {
+  const p_votes = args.votes
+    .filter((v) => v.points > 0)
+    .map((v) => ({ submission_id: v.submissionId, points: v.points }));
+
+  const { error: voteError } = await supabase.rpc("submit_votes", {
+    p_round_id: args.roundId,
+    p_voter_user_id: args.userId,
+    p_votes,
+  });
+  if (voteError) throw postgresToMixError(voteError);
+
+  const commentRows = (args.comments ?? [])
+    .filter((c) => c.body.trim().length > 0)
+    .map((c) => ({
+      round_id: args.roundId,
+      submission_id: c.submissionId,
+      author_user_id: args.userId,
+      body: c.body.trim(),
+    }));
+
+  if (commentRows.length > 0) {
+    const { error: commentError } = await supabase
+      .from("comments")
+      .insert(commentRows);
+    if (commentError) {
+      throw new UnknownMixError(
+        `Votes saved but comments failed: ${commentError.message}`,
+        { cause: commentError },
+      );
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "dev": "turbo run dev --parallel",
+    "gen-types": "supabase gen types typescript --project-id dmkxaqhmcbrzqnpnpicx > packages/db/types.ts",
+    "db:push": "supabase db push && pnpm gen-types",
     "test:setup": "node scripts/test.mjs setup-players",
     "test:create-user": "node scripts/test.mjs create-user",
     "test:join": "node scripts/test.mjs join",

--- a/packages/db/types.ts
+++ b/packages/db/types.ts
@@ -12,31 +12,6 @@ export type Database = {
   __InternalSupabase: {
     PostgrestVersion: "14.5"
   }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
   public: {
     Tables: {
       comments: {
@@ -700,6 +675,7 @@ export type Database = {
           season_number: number
           season_playlist_ref: string | null
           status: string
+          submissions_per_user: number
         }
         Insert: {
           completed_at?: string | null
@@ -714,6 +690,7 @@ export type Database = {
           season_number: number
           season_playlist_ref?: string | null
           status?: string
+          submissions_per_user?: number
         }
         Update: {
           completed_at?: string | null
@@ -728,6 +705,7 @@ export type Database = {
           season_number?: number
           season_playlist_ref?: string | null
           status?: string
+          submissions_per_user?: number
         }
         Relationships: [
           {
@@ -928,17 +906,53 @@ export type Database = {
       }
     }
     Functions: {
+      assign_playlist_positions: { Args: never; Returns: undefined }
+      close_voting_rounds: { Args: never; Returns: undefined }
+      complete_finished_seasons: { Args: never; Returns: undefined }
       create_league: { Args: { league_name: string }; Returns: string }
       get_join_invite_info: {
         Args: { invite_token: string }
         Returns: {
-          season_id: string
-          season_name: string
           league_id: string
           league_name: string
+          season_id: string
+          season_name: string
+          season_status: string
+        }[]
+      }
+      get_round_results: {
+        Args: { p_round_id: string }
+        Returns: {
+          display_name: string
+          is_void: boolean
+          points_effective: number
+          points_raw: number
+          sort_key: number
+          spotify_track_id: string
+          submission_id: string
+          track_artist: string
+          track_artwork_url: string
+          track_isrc: string
+          track_title: string
+          user_id: string
+        }[]
+      }
+      get_season_standings: {
+        Args: { p_season_id: string }
+        Returns: {
+          display_name: string
+          member_role: string
+          rounds_forfeited: number
+          rounds_played: number
+          total_points: number
+          user_id: string
         }[]
       }
       my_league_ids: { Args: never; Returns: string[] }
+      submit_votes: {
+        Args: { p_round_id: string; p_voter_user_id: string; p_votes: Json }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never
@@ -1067,9 +1081,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {},
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.4
         version: 2.101.1
+      '@tanstack/react-query':
+        specifier: ^5.99.2
+        version: 5.99.2(react@19.1.0)
       '@wwdrew/expo-spotify-sdk':
         specifier: ^0.5.0
         version: 0.5.0(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1246,6 +1249,14 @@ packages:
   '@supabase/supabase-js@2.101.1':
     resolution: {integrity: sha512-Jnhm3LfuACwjIzvk2pfUbGQn7pa7hi6MFzfSyPrRYWVCCu69RPLCFyHSBl7HSBwadbQ3UZOznnD3gPca3ePrRA==}
     engines: {node: '>=20.0.0'}
+
+  '@tanstack/query-core@5.99.2':
+    resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
+
+  '@tanstack/react-query@5.99.2':
+    resolution: {integrity: sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@turbo/darwin-64@2.9.4':
     resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
@@ -5060,6 +5071,13 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@tanstack/query-core@5.99.2': {}
+
+  '@tanstack/react-query@5.99.2(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.99.2
+      react: 19.1.0
 
   '@turbo/darwin-64@2.9.4':
     optional: true

--- a/supabase/migrations/20260421000004_submission_close_participants_only.sql
+++ b/supabase/migrations/20260421000004_submission_close_participants_only.sql
@@ -1,0 +1,56 @@
+-- ─── Submission auto-close: count participants only ──────────────────────────
+-- Previous version counted ALL league_members, so any league with a spectator
+-- would never auto-close submissions: spectators can't submit (blocked by
+-- check_submission_eligibility) so v_members_done could never reach
+-- v_total_members. Mirrors the vote auto-close fix in
+-- 20260421000000_non_submitter_vote_guard.sql — compare against the eligible
+-- submitter pool, not the full membership.
+
+CREATE OR REPLACE FUNCTION public.check_submissions_complete()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_league_id          uuid;
+  v_subs_per_user      int;
+  v_total_participants int;
+  v_members_done       int;
+BEGIN
+  SELECT s.league_id, s.submissions_per_user
+    INTO v_league_id, v_subs_per_user
+    FROM rounds r
+    JOIN seasons s ON s.id = r.season_id
+   WHERE r.id = NEW.round_id;
+
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  -- Participants only — spectators are blocked from submitting, so they must
+  -- not count toward the completion threshold.
+  SELECT COUNT(*) INTO v_total_participants
+    FROM league_members
+   WHERE league_id = v_league_id
+     AND role      = 'participant';
+
+  SELECT COUNT(*) INTO v_members_done
+    FROM (
+      SELECT user_id
+        FROM submissions
+       WHERE round_id = NEW.round_id
+      GROUP BY user_id
+      HAVING COUNT(*) >= v_subs_per_user
+    ) complete;
+
+  IF v_members_done >= v_total_participants THEN
+    UPDATE rounds
+       SET submission_deadline_at = now()
+     WHERE id = NEW.round_id
+       AND submission_deadline_at > now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/supabase/migrations/20260421000005_attach_submission_rules_trigger.sql
+++ b/supabase/migrations/20260421000005_attach_submission_rules_trigger.sql
@@ -1,0 +1,18 @@
+-- ─── Re-attach submission rules trigger ──────────────────────────────────────
+-- Migration 20260421000003 restored check_submission_eligibility() (deadline,
+-- quota, sequential-round checks) but left it orphaned: the trigger named
+-- trg_check_submission_eligibility was pointed at the spectator guard, and no
+-- trigger was attached to the restored function.
+--
+-- This adds a second BEFORE INSERT trigger under a distinct name so both
+-- enforcement paths run. Alphabetical fire order puts the spectator check
+-- first (trg_check_submission_eligibility) then the rules check
+-- (trg_check_submission_rules), giving spectators a clearer error before
+-- they hit deadline/quota/sequential logic.
+
+DROP TRIGGER IF EXISTS trg_check_submission_rules ON public.submissions;
+
+CREATE TRIGGER trg_check_submission_rules
+  BEFORE INSERT ON public.submissions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_submission_eligibility();


### PR DESCRIPTION
## Summary
- Extracts every screen's inline `supabase` call into a pure async services layer (`apps/mobile/src/services/`) with typed errors.
- Adds a thin TanStack Query wrapper layer (`apps/mobile/src/queries/`) with a single query-key factory and single invalidation map.
- Rewires every screen (Round, Season, League, CreateLeague, CreateSeason, Join, AuthLogin, Profile, MixTab) to compose hooks — no more `fetchData`.
- Fixes two DB bugs found while wiring errors: submission auto-close miscounted spectators, and the eligibility-rules trigger was orphaned.
- Adds `CLAUDE.md` codifying the pattern, plus `pnpm gen-types` / `pnpm db:push` scripts so DB types stay fresh.

## Why
UI churn shouldn't threaten core functionality. All user-facing actions are now callable as plain functions; screens are dumb compositions. Swap the UI freely.

## Notable
- 12 service modules, ~25 query hooks, one canonical shape to imitate (see `CLAUDE.md`).
- 2 DB migrations included.
- Zero new type errors introduced; pre-existing baseline errors unchanged.

## Test plan
- [x] `pnpm --filter @mix/mobile type-check` — baseline errors only, no regressions
- [x] Voting slice smoke-tested end-to-end (vote submit, auto-close, typed errors surface in Alert)
- [x] Submission slice smoke-tested (search, paste link, submit, edit, deadline/quota errors)
- [x] Spectator-aware submission auto-close verified on a fresh round
- [ ] Re-test season creation + join-via-invite + force-end-voting before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)