### PR TITLE
fix(nav): back button no longer disappears after cancelled zoom dismiss

### DIFF
--- a/apps/mobile/src/app/(tabs)/(home)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/(home)/_layout.tsx
@@ -15,7 +15,22 @@ export default function HomeStackLayout() {
         gestureEnabled: true,
       }}
     >
-      <Stack.Screen name="index"         options={{ headerShown: false }} />
+      {/* Transparent (not hidden) nav bar on the tab root so iOS 18's zoom
+          dismiss gesture doesn't trigger setNavigationBarHidden:YES on the
+          appearing VC. If hidden, react-native-screens animates the bar away
+          during the gesture and never restores it on cancellation, leaving
+          the pushed screen's back button gone. Transparent looks identical. */}
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: true,
+          headerTransparent: true,
+          headerBlurEffect: undefined,
+          headerStyle: { backgroundColor: 'transparent' },
+          headerShadowVisible: false,
+          headerTitle: '',
+        }}
+      />
       <Stack.Screen name="create-league" options={{ title: 'New League' }} />
       <Stack.Screen name="create-season" options={{ title: 'New Season' }} />
       <Stack.Screen name="league/[id]"   options={{ title: 'League' }} />


### PR DESCRIPTION
## Summary
- Pulling down slightly on the round screen (to peek the zoom dismiss) then releasing left the top-left back button gone ~250ms later.
- Root cause: home tab index used \`headerShown: false\`. When the iOS 18 zoom dismiss gesture started, \`react-native-screens\` called \`setNavigationBarHidden:YES animated\` on the appearing home VC (see \`RNSScreenStackHeaderConfig.mm:611\`). That animation completed even when the gesture was cancelled, and nothing restored the bar.
- Fix: swap home root from \`headerShown: false\` → transparent (empty) nav bar. Visually identical; UIKit never hides the bar during the gesture, so cancellation has nothing to leak.

## Test plan
- [ ] On the voting page (zoomed in from home), pull down slightly and release — native back button stays visible.
- [ ] Full pull-down still dismisses back to home.
- [ ] Home screen layout looks unchanged (no shifted content / extra top padding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)