### PR TITLE
SoundCloud submissions + playback fixes

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -29,10 +29,6 @@ import { SoundCloudPlayerProvider } from "@/playback/SoundCloudWebPlayer";
 import { PlaybackProvider } from "@/playback/PlaybackContext";
 import { getValidAccessToken } from "@/lib/spotifyAuth";
 
-// TODO: dev-only nuke, remove before shipping
-import { Image } from "expo-image";
-Image.clearMemoryCache();
-Image.clearDiskCache();
 // UI preview design playground — kept for style/state experimentation.
 // Navigate to it via the [DEV] button in the Profile tab.
 // To permanently remove:

--- a/apps/mobile/src/app/ui-preview/_CoverArt.tsx
+++ b/apps/mobile/src/app/ui-preview/_CoverArt.tsx
@@ -1,2 +1,5 @@
 export { CoverArt } from '@/ui/CoverArt';
 export type { CoverArtPattern } from '@/ui/CoverArt';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/_NowPlayingBar.tsx
+++ b/apps/mobile/src/app/ui-preview/_NowPlayingBar.tsx
@@ -32,3 +32,6 @@ export function NowPlayingBar({
     />
   );
 }
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/_TabBar.tsx
+++ b/apps/mobile/src/app/ui-preview/_TabBar.tsx
@@ -124,3 +124,6 @@ const styles = StyleSheet.create({
     marginTop: 1,
   },
 });
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/_images.ts
+++ b/apps/mobile/src/app/ui-preview/_images.ts
@@ -1,1 +1,4 @@
 export * from '@/ui/theme/images';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/_tokens.ts
+++ b/apps/mobile/src/app/ui-preview/_tokens.ts
@@ -1,2 +1,5 @@
 export * from '@/ui/theme/tokens';
 export { THEME } from '@/ui/theme/tokens';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/_videos.ts
+++ b/apps/mobile/src/app/ui-preview/_videos.ts
@@ -1,1 +1,4 @@
 export * from '@/ui/theme/videos';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/themes/disco.ts
+++ b/apps/mobile/src/app/ui-preview/themes/disco.ts
@@ -1,1 +1,4 @@
 export { DISCO_THEME } from '@/ui/theme/disco';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/themes/index.ts
+++ b/apps/mobile/src/app/ui-preview/themes/index.ts
@@ -1,1 +1,4 @@
 export * from '@/ui/theme';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/app/ui-preview/themes/types.ts
+++ b/apps/mobile/src/app/ui-preview/themes/types.ts
@@ -1,1 +1,4 @@
 export * from '@/ui/theme/types';
+
+// Stub default export so expo-router stops treating this helper as a route.
+export default function PreviewHelperStub() { return null; }

--- a/apps/mobile/src/components/NowPlayingModal.tsx
+++ b/apps/mobile/src/components/NowPlayingModal.tsx
@@ -40,10 +40,18 @@ function SeekBar({
   onSeek: (ms: number) => void;
 }) {
   const [barWidth, setBarWidth] = useState(1);
-  const progress = durationMs > 0 ? Math.min(positionMs / durationMs, 1) : 0;
-  const fillWidth = progress * barWidth;
+  const [dragX, setDragX] = useState<number | null>(null);
 
-  const handleTouch = useCallback(
+  const displayProgress = dragX !== null
+    ? Math.max(0, Math.min(dragX / barWidth, 1))
+    : (durationMs > 0 ? Math.min(positionMs / durationMs, 1) : 0);
+  const fillWidth = displayProgress * barWidth;
+
+  const displayMs = dragX !== null
+    ? Math.round(displayProgress * durationMs)
+    : positionMs;
+
+  const commitSeek = useCallback(
     (x: number) => {
       const ratio = Math.max(0, Math.min(x / barWidth, 1));
       onSeek(Math.round(ratio * durationMs));
@@ -58,8 +66,20 @@ function SeekBar({
         onLayout={(e) => setBarWidth(e.nativeEvent.layout.width)}
         onStartShouldSetResponder={() => true}
         onMoveShouldSetResponder={() => true}
-        onResponderGrant={(e) => handleTouch(e.nativeEvent.locationX)}
-        onResponderMove={(e) => handleTouch(e.nativeEvent.locationX)}
+        // Refuse any parent's request to steal the gesture mid-drag. Without
+        // this, the SwipeSheet's pan responder grabs the touch and fires
+        // onResponderTerminate on us, which would clear dragX for one frame
+        // and snap the thumb back to the underlying positionMs — the
+        // flicker-back-to-start behavior. Releasing the touch still triggers
+        // onResponderRelease normally.
+        onResponderTerminationRequest={() => false}
+        onResponderGrant={(e) => setDragX(e.nativeEvent.locationX)}
+        onResponderMove={(e) => setDragX(e.nativeEvent.locationX)}
+        onResponderRelease={(e) => {
+          commitSeek(e.nativeEvent.locationX);
+          setDragX(null);
+        }}
+        onResponderTerminate={() => setDragX(null)}
       >
         <View style={seekStyles.track}>
           <View style={[seekStyles.fill, { width: fillWidth }]} />
@@ -67,7 +87,7 @@ function SeekBar({
         <View style={[seekStyles.thumb, { left: Math.max(0, fillWidth - 6) }]} />
       </View>
       <View style={seekStyles.labels}>
-        <Text style={seekStyles.time}>{formatMs(positionMs)}</Text>
+        <Text style={seekStyles.time}>{formatMs(displayMs)}</Text>
         <Text style={seekStyles.time}>{durationMs > 0 ? formatMs(durationMs) : '--:--'}</Text>
       </View>
     </View>
@@ -275,7 +295,10 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
   } = usePlayback();
 
   const hasTrack = currentIndex !== null;
-  const hasPrevious = currentIndex !== null && currentIndex > 0;
+  // Back is enabled whenever a track is loaded — `previous()` now does the
+  // standard music-player thing of restarting from 0 if pressed after the
+  // first ~2s of playback, falling through to a previous track otherwise.
+  const canPrevious = currentIndex !== null;
   const hasNext = currentIndex !== null && currentIndex < playlist.length - 1;
 
   return (
@@ -303,7 +326,7 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
             <SeekBar positionMs={positionMs} durationMs={durationMs} onSeek={seek} />
 
             <View style={modalStyles.controls}>
-              <ControlBtn label="⏮" onPress={previous} disabled={!hasPrevious} />
+              <ControlBtn label="⏮" onPress={previous} disabled={!canPrevious} />
               <ControlBtn
                 label={isPlaying ? '⏸' : '▶'}
                 onPress={isPlaying ? pause : resume}

--- a/apps/mobile/src/playback/PlaybackContext.tsx
+++ b/apps/mobile/src/playback/PlaybackContext.tsx
@@ -25,7 +25,6 @@ export interface PlaylistTrack {
 interface PlaybackContextValue {
   // Playlist
   playlist: PlaylistTrack[];
-  setPlaylist: (tracks: PlaylistTrack[]) => void;
   currentIndex: number | null;
 
   // Now-playing (live)
@@ -37,6 +36,7 @@ interface PlaybackContextValue {
   artist: string;
 
   // Commands
+  playPlaylist: (tracks: PlaylistTrack[], startIndex?: number) => void;
   playTrack: (index: number) => void;
   pause: () => void;
   resume: () => void;
@@ -49,7 +49,6 @@ interface PlaybackContextValue {
 
 const PlaybackContext = createContext<PlaybackContextValue>({
   playlist: [],
-  setPlaylist: () => {},
   currentIndex: null,
   isPlaying: false,
   positionMs: 0,
@@ -57,6 +56,7 @@ const PlaybackContext = createContext<PlaybackContextValue>({
   artworkUrl: '',
   title: '',
   artist: '',
+  playPlaylist: () => {},
   playTrack: () => {},
   pause: () => {},
   resume: () => {},
@@ -141,6 +141,19 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
     });
   }, [spotify]);
 
+  // ── Auto-advance on track end ──────────────────────────────────────────────
+
+  const trackEndFiredRef = useRef(false);
+  // Highest extrapolated position seen during continuous playback of the
+  // current track. Used to disambiguate "Spotify reset position to 0 because
+  // the track ended" from "user paused at position 0".
+  const peakPositionRef = useRef(0);
+
+  useEffect(() => {
+    trackEndFiredRef.current = false;
+    peakPositionRef.current = 0;
+  }, [currentIndex]);
+
   // ── Derived now-playing values ─────────────────────────────────────────────
   const isPlaying = activeSource === 'spotify'
     ? !!(
@@ -186,9 +199,20 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
 
   // ── Commands ───────────────────────────────────────────────────────────────
 
-  const playTrack = useCallback((index: number) => {
-    const track = playlist[index];
+  // Mirror playlist into a ref so command callbacks always see the latest
+  // tracks, even when invoked from a stale closure (e.g. setTimeout) or from
+  // the same tick as a setPlaylist call.
+  const playlistRef = useRef<PlaylistTrack[]>(playlist);
+  playlistRef.current = playlist;
+
+  // Internal: actually start a track. Always interrupts whatever is playing.
+  const startTrack = useCallback((tracks: PlaylistTrack[], index: number) => {
+    const track = tracks[index];
     if (!track) return;
+
+    // Reset auto-advance guard for the new track
+    trackEndFiredRef.current = false;
+
     setCurrentIndex(index);
     setActiveSource(track.source);
     setDisplayPositionMs(0);
@@ -200,7 +224,24 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       spotify.abandonMixSpotifySession();
       sc.load(track.uri);
     }
-  }, [playlist, spotify, sc]);
+  }, [spotify, sc]);
+
+  // Public: load a playlist and immediately start a track from it.
+  // Use this from screens — it synchronously sets the playlist and kicks off
+  // playback in one operation, avoiding any stale-closure timing issues.
+  const playPlaylist = useCallback(
+    (tracks: PlaylistTrack[], startIndex: number = 0) => {
+      setPlaylist(tracks);
+      startTrack(tracks, startIndex);
+    },
+    [startTrack],
+  );
+
+  // Public: play a track by index within the currently-loaded playlist.
+  // Used internally by next/previous and from the Now Playing UI.
+  const playTrack = useCallback((index: number) => {
+    startTrack(playlistRef.current, index);
+  }, [startTrack]);
 
   const pause = useCallback(() => {
     if (activeSource === null) return;
@@ -239,24 +280,102 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
   const seek = useCallback((ms: number) => {
     if (activeSource === null) return;
     setDisplayPositionMs(ms);
-    if (activeSource === 'spotify') spotify.seek(ms);
-    else if (activeSource === 'soundcloud') sc.seek(ms);
+    // A fresh seek is a new track-end window — clear the auto-advance guard
+    // so it can re-arm against the new position. Reset the peak too so
+    // seeking *back* from near the end doesn't leave the natural-end
+    // detector primed to fire if the user then pauses near position 0.
+    trackEndFiredRef.current = false;
+    peakPositionRef.current = ms;
+    if (activeSource === 'spotify') {
+      // Re-anchor the extrapolation base to the new seek position so the
+      // 500ms interval doesn't overwrite displayPositionMs with a stale
+      // extrapolation of the OLD position (which can race past durationMs
+      // and spuriously trigger auto-advance).
+      spotifyPosRef.current = {
+        positionMs: ms,
+        timestamp: Date.now(),
+        playing: spotifyPosRef.current.playing,
+      };
+      spotify.seek(ms);
+    } else if (activeSource === 'soundcloud') {
+      sc.seek(ms);
+    }
   }, [activeSource, spotify, sc]);
 
   const next = useCallback(() => {
-    if (currentIndex === null || currentIndex >= playlist.length - 1) return;
+    if (currentIndex === null) return;
+    if (currentIndex >= playlistRef.current.length - 1) return;
     playTrack(currentIndex + 1);
-  }, [currentIndex, playlist.length, playTrack]);
-
-  const previous = useCallback(() => {
-    if (currentIndex === null || currentIndex <= 0) return;
-    playTrack(currentIndex - 1);
   }, [currentIndex, playTrack]);
+
+  // Standard music-player back behavior: tapping back restarts the current
+  // track from 0, *unless* you tap within the first 2s — in that case it
+  // jumps to the previous track. If you're at the first track and >2s in,
+  // tapping back also restarts from 0 (no previous to go to).
+  const PREV_TO_RESTART_THRESHOLD_MS = 2000;
+  const previous = useCallback(() => {
+    if (currentIndex === null) return;
+    const atStartWindow = displayPositionMs <= PREV_TO_RESTART_THRESHOLD_MS;
+    const hasPrevTrack = currentIndex > 0;
+    if (atStartWindow && hasPrevTrack) {
+      playTrack(currentIndex - 1);
+      return;
+    }
+    // Restart current track from 0 (works for both sources via seek()).
+    seek(0);
+  }, [currentIndex, displayPositionMs, playTrack, seek]);
+
+  // Keep a ref so subscription callbacks always see the latest `next`
+  const nextRef = useRef(next);
+  nextRef.current = next;
+
+  // Track the highest extrapolated position seen while the current track is
+  // actively playing. Only grows monotonically — explicit seeks reset it (see
+  // the seek() command above).
+  useEffect(() => {
+    if (activeSource !== 'spotify') return;
+    if (!isPlaying) return;
+    if (displayPositionMs > peakPositionRef.current) {
+      peakPositionRef.current = displayPositionMs;
+    }
+  }, [displayPositionMs, isPlaying, activeSource]);
+
+  // Spotify natural-end detection. Two signals — whichever fires first:
+  //   1. Extrapolated position runs past durationMs while still "playing".
+  //      Happens when Spotify stops firing stateChanged at the very end.
+  //   2. Spotify reports paused + position ≈ 0 *after* we'd been playing near
+  //      the end. That's Spotify's natural-end signature (it resets position
+  //      to 0). We use the peak-position guard to distinguish this from the
+  //      user pausing at the start of the track.
+  useEffect(() => {
+    if (activeSource !== 'spotify') return;
+    if (durationMs <= 0) return;
+    if (trackEndFiredRef.current) return;
+
+    const passedEndWhilePlaying =
+      isPlaying && displayPositionMs >= durationMs;
+
+    const wasNearEnd = peakPositionRef.current >= durationMs - 3000;
+    const positionResetAfterPlaying =
+      !isPlaying && wasNearEnd && displayPositionMs < 1500;
+
+    if (passedEndWhilePlaying || positionResetAfterPlaying) {
+      trackEndFiredRef.current = true;
+      nextRef.current();
+    }
+  }, [displayPositionMs, durationMs, isPlaying, activeSource]);
+
+  // SoundCloud: FINISH event fired from the widget
+  useEffect(() => {
+    return sc.subscribeTrackEnd(() => {
+      if (activeSourceRef.current !== 'soundcloud') return;
+      nextRef.current();
+    });
+  }, [sc]);
 
   return (
     <PlaybackContext.Provider value={{
       playlist,
-      setPlaylist,
       currentIndex,
       isPlaying,
       positionMs: displayPositionMs,
@@ -264,6 +383,7 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       artworkUrl,
       title,
       artist,
+      playPlaylist,
       playTrack,
       pause,
       resume,

--- a/apps/mobile/src/playback/SoundCloudWebPlayer.tsx
+++ b/apps/mobile/src/playback/SoundCloudWebPlayer.tsx
@@ -26,6 +26,7 @@ interface SoundCloudPlayerContextValue {
   play: () => void;
   pause: () => void;
   seek: (ms: number) => void;
+  subscribeTrackEnd: (listener: () => void) => () => void;
 }
 
 // ─── HTML ─────────────────────────────────────────────────────────────────────
@@ -84,8 +85,20 @@ const PLAYER_HTML = `
     emitState(true);
   });
 
+  // SC's PLAY_PROGRESS fires several times per second while a track is
+  // playing. Capture the latest position into the closure and trickle a
+  // throttled stateChanged across the bridge so React's displayPositionMs
+  // (and the SeekBar) keep ticking. Without this, the time label stays
+  // frozen at whatever the last PLAY/PAUSE event carried — visible as
+  // (a) scrub-then-play stuck at the drop position and (b) 0:00 after
+  // an auto-advance into an SC track from a Spotify track.
+  var lastProgressEmit = 0;
   widget.bind(SC.Widget.Events.PLAY_PROGRESS, function(e) {
     currentPosition = e.currentPosition;
+    var now = Date.now();
+    if (now - lastProgressEmit < 500) return;
+    lastProgressEmit = now;
+    emitState(false);
   });
 
   widget.bind(SC.Widget.Events.FINISH, function() {
@@ -126,6 +139,7 @@ const SoundCloudPlayerContext = createContext<SoundCloudPlayerContextValue>({
   play: () => {},
   pause: () => {},
   seek: () => {},
+  subscribeTrackEnd: () => () => {},
 });
 
 export function useSoundCloudPlayer() {
@@ -138,6 +152,13 @@ export function SoundCloudPlayerProvider({ children }: { children: React.ReactNo
   const webViewRef = useRef<WebView>(null);
   const [isReady, setIsReady] = useState(false);
   const [trackState, setTrackState] = useState<SoundCloudTrackState | null>(null);
+  const trackEndListenersRef = useRef(new Set<() => void>());
+
+  const subscribeTrackEnd = useCallback((listener: () => void) => {
+    const set = trackEndListenersRef.current;
+    set.add(listener);
+    return () => { set.delete(listener); };
+  }, []);
 
   const inject = useCallback((js: string) => {
     webViewRef.current?.injectJavaScript(`${js}; true;`);
@@ -152,6 +173,9 @@ export function SoundCloudPlayerProvider({ children }: { children: React.ReactNo
         setTrackState(msg.state);
       } else if (msg.type === 'finished') {
         setTrackState((s) => s ? { ...s, isPaused: true } : s);
+        for (const fn of [...trackEndListenersRef.current]) {
+          try { fn(); } catch {}
+        }
       } else if (msg.type === 'error') {
         console.warn('[SoundCloudPlayer] error:', msg.message);
       }
@@ -167,7 +191,7 @@ export function SoundCloudPlayerProvider({ children }: { children: React.ReactNo
   const seek = useCallback((ms: number) => inject(`window.scSeek(${ms})`), [inject]);
 
   return (
-    <SoundCloudPlayerContext.Provider value={{ isReady, trackState, load, play, pause, seek }}>
+    <SoundCloudPlayerContext.Provider value={{ isReady, trackState, load, play, pause, seek, subscribeTrackEnd }}>
       <View style={styles.hidden}>
         <WebView
           ref={webViewRef}

--- a/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
+++ b/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
@@ -61,7 +61,9 @@ type Submission = {
   track_title: string;
   track_artist: string;
   track_artwork_url: string | null;
+  track_source: "spotify" | "soundcloud";
   spotify_track_id: string | null;
+  soundcloud_track_url: string | null;
   track_isrc: string;
   comment: string | null;
   created_at?: string;
@@ -83,16 +85,29 @@ function pastelFor(id: string): string {
 }
 
 function submissionToPlaylistTrack(s: Submission): PlaylistTrack | null {
-  if (!s.spotify_track_id) return null;
-  return {
-    id: s.id,
-    source: "spotify",
-    uri: normalizeSpotifyTrackUri(s.spotify_track_id),
-    title: s.track_title,
-    artist: s.track_artist,
-    artworkUrl: s.track_artwork_url ?? "",
-    durationMs: 0,
-  };
+  if (s.track_source === "soundcloud" && s.soundcloud_track_url) {
+    return {
+      id: s.id,
+      source: "soundcloud",
+      uri: s.soundcloud_track_url,
+      title: s.track_title,
+      artist: s.track_artist,
+      artworkUrl: s.track_artwork_url ?? "",
+      durationMs: 0,
+    };
+  }
+  if (s.spotify_track_id) {
+    return {
+      id: s.id,
+      source: "spotify",
+      uri: normalizeSpotifyTrackUri(s.spotify_track_id),
+      title: s.track_title,
+      artist: s.track_artist,
+      artworkUrl: s.track_artwork_url ?? "",
+      durationMs: 0,
+    };
+  }
+  return null;
 }
 
 // ─── Screen ───────────────────────────────────────────────────────────────────
@@ -144,8 +159,7 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
 
   const onPlay = () => {
     if (orderedPlaylist.length === 0) return;
-    playback.setPlaylist(orderedPlaylist);
-    setTimeout(() => playback.playTrack(0), 0);
+    playback.playPlaylist(orderedPlaylist, 0);
   };
 
   const onAddToSpotify = () => {
@@ -262,6 +276,11 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
                 isWinner={winningSubId === sub.id}
                 voters={votersData[sub.id] ?? []}
                 isLast={idx === submissions.length - 1}
+                isCurrentTrack={playback.currentIndex === idx}
+                onPress={() => {
+                  if (orderedPlaylist.length === 0) return;
+                  playback.playPlaylist(orderedPlaylist, idx);
+                }}
               />
             ))}
           </View>
@@ -287,6 +306,8 @@ function PlaylistTrackRow({
   isWinner,
   voters,
   isLast,
+  isCurrentTrack,
+  onPress,
 }: {
   index: number;
   submission: Submission;
@@ -294,6 +315,8 @@ function PlaylistTrackRow({
   isWinner: boolean;
   voters: VoterRow[];
   isLast: boolean;
+  isCurrentTrack: boolean;
+  onPress: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   // Visible voters in the accordion: comment authors only (this screen is
@@ -317,8 +340,10 @@ function PlaylistTrackRow({
 
   return (
     <View>
-      <View style={styles.row}>
-        <Text style={styles.rowNum}>{String(index + 1).padStart(2, "0")}</Text>
+      <TouchableOpacity activeOpacity={0.7} onPress={onPress} style={styles.row}>
+        <Text style={[styles.rowNum, isCurrentTrack && styles.rowNumActive]}>
+          {isCurrentTrack ? "▶" : String(index + 1).padStart(2, "0")}
+        </Text>
         {submission.track_artwork_url ? (
           <ChromeBorder
             radius={8}
@@ -379,7 +404,7 @@ function PlaylistTrackRow({
         <View style={styles.ptsPill}>
           <Text style={styles.ptsPillText}>+{points}</Text>
         </View>
-      </View>
+      </TouchableOpacity>
 
       {expanded && hasComments ? (
         <View style={styles.commentsAccordion}>
@@ -540,6 +565,11 @@ const styles = StyleSheet.create({
     color: THEME.muted,
     width: 22,
     textAlign: "left",
+  },
+  rowNumActive: {
+    color: THEME.ink,
+    fontSize: 12,
+    letterSpacing: 0,
   },
   rowArt: {
     width: 44,

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -65,6 +65,11 @@ import {
   getSpotifyTrack,
   extractSpotifyTrackId,
 } from "@/services/spotifySearch";
+import {
+  isSoundCloudTrackUrl,
+  resolveSoundCloudTrack,
+  type SoundCloudTrack,
+} from "@/services/soundcloudResolve";
 import { THEME } from "@/ui/theme";
 import { PageHeader } from "@/ui/PageHeader";
 import { HeroBanner } from "@/ui/cards/HeroBanner";
@@ -109,7 +114,9 @@ type Submission = {
   track_title: string;
   track_artist: string;
   track_artwork_url: string | null;
+  track_source: "spotify" | "soundcloud";
   spotify_track_id: string | null;
+  soundcloud_track_url: string | null;
   track_isrc: string;
   comment: string | null;
 };
@@ -124,12 +131,39 @@ type SpotifyTrack = {
   popularity: number;
 };
 
+// Discriminated track shape used by the picker UI for both search results and
+// the committed slot. Whichever streaming source the user picked, the
+// downstream submit logic dispatches on `source` to populate the right DB
+// columns. The Spotify branch keeps the full SDK shape so we have ISRC,
+// popularity, etc. on hand for analytics. The SoundCloud branch only has what
+// oEmbed gives us.
+type PickedTrack =
+  | { source: "spotify"; data: SpotifyTrack }
+  | { source: "soundcloud"; data: SoundCloudTrack };
+
+function pickedId(t: PickedTrack): string {
+  return t.source === "spotify" ? t.data.id : t.data.url;
+}
+function pickedTitle(t: PickedTrack): string {
+  return t.source === "spotify" ? t.data.name : t.data.title;
+}
+function pickedArtist(t: PickedTrack): string {
+  return t.source === "spotify"
+    ? t.data.artists.map((a) => a.name).join(", ")
+    : t.data.artist;
+}
+function pickedArtwork(t: PickedTrack): string | null {
+  return t.source === "spotify"
+    ? (t.data.album.images[0]?.url ?? null)
+    : t.data.artworkUrl;
+}
+
 type DraftSubmission = {
   submissionId: string | null;
-  track: SpotifyTrack | null;
+  track: PickedTrack | null;
   comment: string;
   searchInput: string;
-  searchResults: SpotifyTrack[];
+  searchResults: PickedTrack[];
   isSearching: boolean;
   isEditingTrack: boolean;
 };
@@ -145,23 +179,39 @@ function formatDeadline(iso: string) {
   });
 }
 
-function submissionToTrack(submission: Submission): SpotifyTrack {
+function submissionToTrack(submission: Submission): PickedTrack {
+  if (submission.track_source === "soundcloud" && submission.soundcloud_track_url) {
+    return {
+      source: "soundcloud",
+      data: {
+        url: submission.soundcloud_track_url,
+        title: submission.track_title,
+        artist: submission.track_artist,
+        artworkUrl: submission.track_artwork_url,
+      },
+    };
+  }
+  // Default: Spotify-shaped (covers existing rows whose track_source defaults
+  // to 'spotify' even if the column wasn't populated yet).
   return {
-    id: submission.spotify_track_id ?? submission.id,
-    name: submission.track_title,
-    artists: submission.track_artist
-      .split(",")
-      .map((artist) => ({ name: artist.trim() }))
-      .filter((artist) => artist.name.length > 0),
-    album: {
-      name: "",
-      images: submission.track_artwork_url
-        ? [{ url: submission.track_artwork_url }]
-        : [],
+    source: "spotify",
+    data: {
+      id: submission.spotify_track_id ?? submission.id,
+      name: submission.track_title,
+      artists: submission.track_artist
+        .split(",")
+        .map((artist) => ({ name: artist.trim() }))
+        .filter((artist) => artist.name.length > 0),
+      album: {
+        name: "",
+        images: submission.track_artwork_url
+          ? [{ url: submission.track_artwork_url }]
+          : [],
+      },
+      duration_ms: 0,
+      external_ids: { isrc: submission.track_isrc },
+      popularity: 0,
     },
-    duration_ms: 0,
-    external_ids: { isrc: submission.track_isrc },
-    popularity: 0,
   };
 }
 
@@ -185,25 +235,35 @@ function createDraftSubmission(
 
 function comparableDraft(draft: DraftSubmission) {
   return {
-    trackId: draft.track?.id ?? null,
+    trackId: draft.track ? pickedId(draft.track) : null,
     comment: draft.comment.trim(),
   };
 }
 
-// Submission rows are spotify-only today. Once SoundCloud is wired into the
-// data model we'll dispatch on the URI source here.
-// TODO: redesign in v2 — support multi-source submissions.
 function submissionToPlaylistTrack(s: Submission): PlaylistTrack | null {
-  if (!s.spotify_track_id) return null;
-  return {
-    id: s.id,
-    source: "spotify",
-    uri: normalizeSpotifyTrackUri(s.spotify_track_id),
-    title: s.track_title,
-    artist: s.track_artist,
-    artworkUrl: s.track_artwork_url ?? "",
-    durationMs: 0,
-  };
+  if (s.track_source === "soundcloud" && s.soundcloud_track_url) {
+    return {
+      id: s.id,
+      source: "soundcloud",
+      uri: s.soundcloud_track_url,
+      title: s.track_title,
+      artist: s.track_artist,
+      artworkUrl: s.track_artwork_url ?? "",
+      durationMs: 0,
+    };
+  }
+  if (s.spotify_track_id) {
+    return {
+      id: s.id,
+      source: "spotify",
+      uri: normalizeSpotifyTrackUri(s.spotify_track_id),
+      title: s.track_title,
+      artist: s.track_artist,
+      artworkUrl: s.track_artwork_url ?? "",
+      durationMs: 0,
+    };
+  }
+  return null;
 }
 
 function shuffled<T>(arr: T[]): T[] {
@@ -392,10 +452,35 @@ function SubmissionPhase({
       setSearchState(slotIndex, { isSearching: true });
 
       try {
-        const linkedTrackId = extractSpotifyTrackId(trimmed);
-        const nextResults = linkedTrackId
-          ? [await getSpotifyTrack(linkedTrackId)]
-          : await searchSpotifyTracks(trimmed);
+        let nextResults: PickedTrack[];
+        // Anything that looks like a URL is treated as URL-mode: we never run
+        // a Spotify text search on a link (otherwise pasting "https://..."
+        // returns garbage Spotify hits matching the literal URL string).
+        const looksLikeUrl = /^https?:\/\//i.test(trimmed);
+        if (isSoundCloudTrackUrl(trimmed)) {
+          // SoundCloud link paste (including share short links) — resolve via
+          // oEmbed and surface as a single preview result.
+          const sc = await resolveSoundCloudTrack(trimmed);
+          nextResults = [{ source: "soundcloud", data: sc }];
+        } else if (looksLikeUrl) {
+          // Could still be a Spotify track URL — handle that. Any other URL
+          // (Apple Music, YouTube, random) returns an empty result set rather
+          // than falling through to text search.
+          const spotifyId = extractSpotifyTrackId(trimmed);
+          if (spotifyId) {
+            const t = await getSpotifyTrack(spotifyId);
+            nextResults = [{ source: "spotify", data: t }];
+          } else {
+            nextResults = [];
+          }
+        } else {
+          // Plain text query → Spotify search.
+          const spotifyResults = await searchSpotifyTracks(trimmed);
+          nextResults = spotifyResults.map((t) => ({
+            source: "spotify" as const,
+            data: t,
+          }));
+        }
 
         if (searchRequestIds.current[slotIndex] !== requestId) return;
         setSearchState(slotIndex, {
@@ -441,9 +526,13 @@ function SubmissionPhase({
     });
   };
 
-  const selectTrack = (slotIndex: number, track: SpotifyTrack) => {
+  const selectTrack = (slotIndex: number, track: PickedTrack) => {
+    const incomingId = pickedId(track);
     const duplicateSlot = drafts.findIndex(
-      (draft, i) => i !== slotIndex && draft.track?.id === track.id,
+      (draft, i) =>
+        i !== slotIndex &&
+        draft.track !== null &&
+        pickedId(draft.track) === incomingId,
     );
     if (duplicateSlot !== -1) {
       Alert.alert(
@@ -515,20 +604,35 @@ function SubmissionPhase({
     }
 
     const payload: SubmissionDraft[] = drafts
-      .filter((d) => d.track)
+      .filter((d): d is DraftSubmission & { track: PickedTrack } => !!d.track)
       .map((d) => {
-        const t = d.track as SpotifyTrack;
+        if (d.track.source === "spotify") {
+          const t = d.track.data;
+          return {
+            submissionId: d.submissionId,
+            track: {
+              source: "spotify" as const,
+              spotifyTrackId: t.id,
+              title: t.name,
+              artist: t.artists.map((a) => a.name).join(", "),
+              artworkUrl: t.album.images[0]?.url ?? null,
+              isrc: t.external_ids?.isrc ?? null,
+              albumName: t.album.name || null,
+              durationMs: t.duration_ms || null,
+              popularity: t.popularity || null,
+            },
+            comment: d.comment,
+          };
+        }
+        const t = d.track.data;
         return {
           submissionId: d.submissionId,
           track: {
-            spotifyTrackId: t.id,
-            title: t.name,
-            artist: t.artists.map((a) => a.name).join(", "),
-            artworkUrl: t.album.images[0]?.url ?? null,
-            isrc: t.external_ids?.isrc ?? null,
-            albumName: t.album.name || null,
-            durationMs: t.duration_ms || null,
-            popularity: t.popularity || null,
+            source: "soundcloud" as const,
+            soundcloudTrackUrl: t.url,
+            title: t.title,
+            artist: t.artist,
+            artworkUrl: t.artworkUrl,
           },
           comment: d.comment,
         };
@@ -603,9 +707,9 @@ function SubmissionPhase({
                 </View>
 
                 <View style={styles.pickTrackRow}>
-                  {draft.track.album.images[0]?.url ? (
+                  {pickedArtwork(draft.track) ? (
                     <Image
-                      source={{ uri: draft.track.album.images[0].url }}
+                      source={{ uri: pickedArtwork(draft.track) as string }}
                       style={styles.pickArt}
                     />
                   ) : (
@@ -613,10 +717,10 @@ function SubmissionPhase({
                   )}
                   <View style={styles.pickMeta}>
                     <Text style={styles.pickTitle} numberOfLines={1}>
-                      {draft.track.name}
+                      {pickedTitle(draft.track)}
                     </Text>
                     <Text style={styles.pickArtist} numberOfLines={1}>
-                      {draft.track.artists.map((a) => a.name).join(", ")}
+                      {pickedArtist(draft.track)}
                     </Text>
                   </View>
                 </View>
@@ -659,7 +763,7 @@ function SubmissionPhase({
                   <Text style={styles.searchGlyph}>⌕</Text>
                   <TextInput
                     style={styles.searchInput}
-                    placeholder="search spotify or paste a link"
+                    placeholder="search spotify or paste a spotify / soundcloud link"
                     placeholderTextColor={THEME.muted}
                     value={draft.searchInput}
                     onChangeText={(value) => updateSearchInput(index, value)}
@@ -679,14 +783,14 @@ function SubmissionPhase({
 
               {draft.searchResults.map((track) => (
                 <TouchableOpacity
-                  key={`${index}-${track.id}`}
+                  key={`${index}-${pickedId(track)}`}
                   style={styles.searchResultRow}
                   onPress={() => selectTrack(index, track)}
                 >
-                  {track.album.images[0]?.url ? (
+                  {pickedArtwork(track) ? (
                     <ChromeBorder radius={8} thickness={1} clip style={styles.searchResultArt}>
                       <Image
-                        source={{ uri: track.album.images[0].url }}
+                        source={{ uri: pickedArtwork(track) as string }}
                         style={{ width: "100%", height: "100%" }}
                       />
                     </ChromeBorder>
@@ -700,10 +804,10 @@ function SubmissionPhase({
                   )}
                   <View style={styles.searchResultMeta}>
                     <Text style={styles.searchResultTitle} numberOfLines={1}>
-                      {track.name}
+                      {pickedTitle(track)}
                     </Text>
                     <Text style={styles.searchResultArtist} numberOfLines={1}>
-                      {track.artists.map((a) => a.name).join(", ")}
+                      {pickedArtist(track)}
                     </Text>
                   </View>
                   <ChromeBorder
@@ -927,9 +1031,23 @@ function VotingScreenContent({
 
   const onPlay = () => {
     if (orderedPlaylist.length === 0) return;
-    playback.setPlaylist(orderedPlaylist);
-    setTimeout(() => playback.playTrack(0), 0);
+    playback.playPlaylist(orderedPlaylist, 0);
   };
+
+  // Tap a vote row to start playing that track. Submissions without a Spotify
+  // ID aren't in orderedPlaylist (filtered above) and become non-interactive.
+  const onPlaySubmission = (subId: string) => {
+    const idx = orderedPlaylist.findIndex((t) => t.id === subId);
+    if (idx === -1) return;
+    playback.playPlaylist(orderedPlaylist, idx);
+  };
+
+  // Which submission is currently playing (regardless of where playback was
+  // started from) — used to flag the active row.
+  const currentPlayingSubId =
+    playback.currentIndex !== null
+      ? playback.playlist[playback.currentIndex]?.id ?? null
+      : null;
 
   // TODO(spotify): wire to real "save playlist to Spotify" once the backend
   // hook exists. Stubbed so the button reads as functional today.
@@ -1125,36 +1243,58 @@ function VotingScreenContent({
             submitting || !canEdit || pts === 0 || isOwn;
           const isCommentOpen = expandedCommentId === sub.id;
           const showVoteUI = canEdit && !isOwn;
+          const isCurrentTrack = currentPlayingSubId === sub.id;
+          const isPlayable = !!sub.spotify_track_id || !!sub.soundcloud_track_url;
 
           return (
             <View key={sub.id}>
               <View style={styles.voteRow}>
-                <Text style={styles.voteRowNum}>{trackNum}</Text>
-                {sub.track_artwork_url ? (
-                  <ChromeBorder
-                    radius={8}
-                    thickness={1}
-                    clip
-                    style={styles.voteRowArt}
+                <TouchableOpacity
+                  activeOpacity={0.7}
+                  onPress={() => onPlaySubmission(sub.id)}
+                  disabled={!isPlayable}
+                  style={styles.voteRowTapArea}
+                >
+                  <Text
+                    style={[
+                      styles.voteRowNum,
+                      isCurrentTrack && styles.voteRowNumActive,
+                    ]}
                   >
-                    <Image
-                      source={{ uri: sub.track_artwork_url }}
-                      style={{ width: "100%", height: "100%" }}
+                    {isCurrentTrack ? "▶" : trackNum}
+                  </Text>
+                  {sub.track_artwork_url ? (
+                    <ChromeBorder
+                      radius={8}
+                      thickness={1}
+                      clip
+                      style={styles.voteRowArt}
+                    >
+                      <Image
+                        source={{ uri: sub.track_artwork_url }}
+                        style={{ width: "100%", height: "100%" }}
+                      />
+                    </ChromeBorder>
+                  ) : (
+                    <View
+                      style={[styles.voteRowArt, styles.voteRowArtPlaceholder]}
                     />
-                  </ChromeBorder>
-                ) : (
-                  <View
-                    style={[styles.voteRowArt, styles.voteRowArtPlaceholder]}
-                  />
-                )}
-                <View style={styles.voteRowMeta}>
-                  <Text style={styles.voteRowTitle} numberOfLines={1}>
-                    {sub.track_title}
-                  </Text>
-                  <Text style={styles.voteRowArtist} numberOfLines={1}>
-                    {sub.track_artist}
-                  </Text>
-                </View>
+                  )}
+                  <View style={styles.voteRowMeta}>
+                    <Text style={styles.voteRowTitle} numberOfLines={1}>
+                      {sub.track_title}
+                    </Text>
+                    <Text style={styles.voteRowArtist} numberOfLines={1}>
+                      {sub.track_artist}
+                    </Text>
+                  </View>
+                  {/* Own-track label sits inside the tap area — it's a passive
+                      label, not a control, so including it keeps the whole row
+                      tappable when there's nothing interactive on the right. */}
+                  {isOwn ? (
+                    <Text style={styles.voteOwnLabel}>YOUR{"\n"}TRACK</Text>
+                  ) : null}
+                </TouchableOpacity>
 
                 {showVoteUI ? (
                   <View style={styles.voteStack}>
@@ -1194,9 +1334,7 @@ function VotingScreenContent({
                       />
                     </TouchableOpacity>
                   </View>
-                ) : isOwn ? (
-                  <Text style={styles.voteOwnLabel}>YOUR{"\n"}TRACK</Text>
-                ) : showSubmittedView ? (
+                ) : !isOwn && showSubmittedView ? (
                   <View style={styles.voteStack}>
                     <Text style={styles.voteCount}>{pts}</Text>
                     <Text style={styles.voteLocked}>pts</Text>
@@ -1755,15 +1893,12 @@ function ResultsPhase({
 
   const onPlay = () => {
     if (orderedPlaylist.length === 0) return;
-    playback.setPlaylist(orderedPlaylist);
-    // setPlaylist is React state; play on the next tick.
-    setTimeout(() => playback.playTrack(0), 0);
+    playback.playPlaylist(orderedPlaylist, 0);
   };
 
   const onShuffle = () => {
     if (orderedPlaylist.length === 0) return;
-    playback.setPlaylist(shuffled(orderedPlaylist));
-    setTimeout(() => playback.playTrack(0), 0);
+    playback.playPlaylist(shuffled(orderedPlaylist), 0);
   };
 
   if (loading) {
@@ -3564,6 +3699,12 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     gap: 10,
   },
+  voteRowTapArea: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
   voteRowNum: {
     fontFamily: THEME.fonts.monoBold,
     fontSize: 11,
@@ -3571,6 +3712,11 @@ const styles = StyleSheet.create({
     color: THEME.muted,
     width: 22,
     textAlign: "left",
+  },
+  voteRowNumActive: {
+    color: THEME.ink,
+    fontSize: 12,
+    letterSpacing: 0,
   },
   voteRowArt: {
     width: 44,

--- a/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Alert } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePlayback } from '@/playback/PlaybackContext';
 import { useSession } from '@/context/SessionContext';
@@ -151,23 +151,8 @@ export function ProfileTabScreen() {
     previous,
   } = usePlayback();
   const { session, supabaseUserId, signOut } = useSession();
-  const { activeLeague, setActiveLeagueId, activeLeagueId } = useLeague();
+  const { setActiveLeagueId, activeLeagueId } = useLeague();
   const { data: leagues = [] } = useMyLeagues(supabaseUserId ?? undefined);
-
-  const handleSwitchLeague = () => {
-    if (leagues.length === 0) { Alert.alert('No leagues found'); return; }
-    Alert.alert(
-      'Switch League',
-      `Active: ${activeLeague?.name ?? activeLeagueId ?? 'none'}`,
-      [
-        ...leagues.map((l) => ({
-          text: l.id === activeLeagueId ? `✓ ${l.name}` : l.name,
-          onPress: () => setActiveLeagueId(l.id),
-        })),
-        { text: 'Cancel', style: 'cancel' as const },
-      ],
-    );
-  };
 
   const hasTrack = currentIndex !== null;
   const hasPrevious = currentIndex !== null && currentIndex > 0;
@@ -198,9 +183,31 @@ export function ProfileTabScreen() {
         <TouchableOpacity style={styles.signOutBtn} onPress={signOut}>
           <Text style={styles.signOutLabel}>Sign Out</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.devBtn} onPress={handleSwitchLeague}>
-          <Text style={styles.devBtnLabel}>[DEV] Switch League</Text>
-        </TouchableOpacity>
+      </View>
+
+      {/* ── League switcher (dev) ── */}
+      <View style={styles.leagueSection}>
+        <Text style={styles.sectionTitle}>[DEV] LEAGUES</Text>
+        {leagues.length === 0 ? (
+          <Text style={styles.leagueEmpty}>Not in any league yet.</Text>
+        ) : (
+          leagues.map((l) => {
+            const active = l.id === activeLeagueId;
+            return (
+              <TouchableOpacity
+                key={l.id}
+                style={[styles.leagueRow, active && styles.leagueRowActive]}
+                onPress={() => setActiveLeagueId(l.id)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.leagueName, active && styles.leagueNameActive]} numberOfLines={1}>
+                  {active ? '● ' : '○ '}{l.name}
+                </Text>
+                <Text style={styles.leagueId} numberOfLines={1}>{l.id}</Text>
+              </TouchableOpacity>
+            );
+          })
+        )}
       </View>
 
       {/* ── Now Playing ── */}
@@ -268,8 +275,25 @@ const styles = StyleSheet.create({
     borderColor: '#333',
   },
   signOutLabel: { fontSize: 14, color: '#666' },
-  devBtn: { paddingVertical: 6, paddingHorizontal: 12 },
-  devBtnLabel: { fontSize: 12, color: '#444' },
+
+  // League switcher (dev)
+  leagueSection: { gap: 8 },
+  leagueEmpty: { fontSize: 13, color: '#555', fontStyle: 'italic' },
+  leagueRow: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    backgroundColor: '#111',
+    borderWidth: 1,
+    borderColor: '#222',
+  },
+  leagueRowActive: {
+    backgroundColor: '#1a1a2e',
+    borderColor: '#3a3a6a',
+  },
+  leagueName: { fontSize: 14, color: '#888', fontWeight: '600' },
+  leagueNameActive: { color: '#fff' },
+  leagueId: { fontSize: 10, color: '#444', marginTop: 2, fontFamily: 'JetBrainsMono_700Bold' },
 
   // Now Playing section
   playerSection: { alignItems: 'center', gap: 16 },

--- a/apps/mobile/src/services/errors.ts
+++ b/apps/mobile/src/services/errors.ts
@@ -83,6 +83,12 @@ export class NotLeagueMemberError extends MixError {
   }
 }
 
+export class DuplicateTrackError extends MixError {
+  constructor(cause?: unknown) {
+    super("Someone already submitted this track for this round.", { cause });
+  }
+}
+
 // ─── Auth / generic ───────────────────────────────────────────────────────────
 
 export class NotAuthenticatedError extends MixError {
@@ -121,6 +127,18 @@ export function postgresToMixError(err: { message?: string | null } | null | und
   if (msg.includes("Previous round is still in progress")) return new PreviousRoundInProgressError(err);
   if (msg.includes("Spectators cannot submit")) return new SpectatorCannotSubmitError(err);
   if (msg.includes("not a member of this league")) return new NotLeagueMemberError(err);
+
+  // Unique-constraint violations on the round-dedup indexes. Index names line
+  // up with what the schema defines; the legacy `unique_track_per_round`
+  // constraint name is also matched so pre-migration deployments still get a
+  // typed error.
+  if (
+    msg.includes("unique_track_per_round") ||
+    msg.includes("submissions_unique_spotify_isrc_per_round") ||
+    msg.includes("submissions_unique_soundcloud_url_per_round")
+  ) {
+    return new DuplicateTrackError(err);
+  }
 
   return new UnknownMixError(msg, { cause: err });
 }

--- a/apps/mobile/src/services/soundcloudResolve.ts
+++ b/apps/mobile/src/services/soundcloudResolve.ts
@@ -1,0 +1,131 @@
+import { UnknownMixError } from "./errors";
+
+export type SoundCloudTrack = {
+  url: string;
+  title: string;
+  artist: string;
+  artworkUrl: string | null;
+};
+
+// SoundCloud track URLs come in a few flavours:
+//   https://soundcloud.com/<artist>/<track-slug>             (canonical)
+//   https://m.soundcloud.com/<artist>/<track-slug>           (mobile)
+//   https://on.soundcloud.com/<opaque-id>                    (share short link)
+//   https://snd.sc/<opaque-id>                               (legacy short link)
+// The canonical/mobile form needs path validation (reject /sets/, /discover/);
+// the short forms have an opaque single-segment path and need to be resolved
+// via redirect before we know what they point to — we accept them at the
+// detector level and let resolveSoundCloudTrack chase the redirect.
+const SC_LONG_HOST_RE = /^https?:\/\/(?:www\.|m\.)?soundcloud\.com\//i;
+const SC_SHORT_HOST_RE = /^https?:\/\/(?:on\.soundcloud\.com|snd\.sc)\//i;
+const REJECTED_FIRST_SEGMENTS = new Set([
+  "sets",
+  "discover",
+  "stations",
+  "you",
+  "pages",
+  "mobile",
+  "tags",
+]);
+
+export function isSoundCloudTrackUrl(input: string): boolean {
+  const trimmed = input.trim();
+  if (SC_SHORT_HOST_RE.test(trimmed)) return true;
+  if (!SC_LONG_HOST_RE.test(trimmed)) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  // Path must be /<artist>/<track-slug>[/...]. Reject any first segment that
+  // we know to be a non-track route.
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length < 2) return false;
+  if (REJECTED_FIRST_SEGMENTS.has(segments[0]!.toLowerCase())) return false;
+  return true;
+}
+
+function isShortScUrl(input: string): boolean {
+  return SC_SHORT_HOST_RE.test(input.trim());
+}
+
+// Follows redirects on a SoundCloud short URL (on.soundcloud.com / snd.sc) to
+// recover the canonical track URL. Returns the input as-is if it's already
+// canonical or if the redirect can't be resolved.
+async function resolveScRedirect(url: string): Promise<string> {
+  try {
+    // HEAD avoids downloading the HTML page; `Response.url` reflects the final
+    // URL after redirects.
+    const res = await fetch(url, { method: "HEAD", redirect: "follow" });
+    return res.url || url;
+  } catch {
+    return url;
+  }
+}
+
+// Strip the tracking params SoundCloud appends from shares (?si=, ?utm_*).
+// The widget accepts them but they make the canonical URL noisy — we'd
+// rather store the clean URL.
+function canonicalScUrl(input: string): string {
+  try {
+    const u = new URL(input.trim());
+    // Drop everything but the path; SC's player only needs the canonical
+    // host + path.
+    u.search = "";
+    u.hash = "";
+    return u.toString();
+  } catch {
+    return input.trim();
+  }
+}
+
+type OEmbedResponse = {
+  title?: string;
+  author_name?: string;
+  thumbnail_url?: string;
+};
+
+// Resolves a SoundCloud track URL to displayable metadata via the public
+// oEmbed endpoint (no auth, no API key). Used both in the submission picker
+// (preview before commit) and to populate submission metadata. Handles share
+// short links (on.soundcloud.com / snd.sc) by chasing the redirect to recover
+// the canonical track URL first.
+export async function resolveSoundCloudTrack(
+  rawUrl: string,
+): Promise<SoundCloudTrack> {
+  if (!isSoundCloudTrackUrl(rawUrl)) {
+    throw new UnknownMixError("Not a SoundCloud track URL");
+  }
+  // Short share URLs must be resolved to a canonical /artist/track URL before
+  // oEmbed will recognize them.
+  const resolved = isShortScUrl(rawUrl)
+    ? await resolveScRedirect(rawUrl.trim())
+    : rawUrl;
+  const url = canonicalScUrl(resolved);
+  const oembedUrl = `https://soundcloud.com/oembed?url=${encodeURIComponent(url)}&format=json`;
+  let res: Response;
+  try {
+    res = await fetch(oembedUrl);
+  } catch {
+    throw new UnknownMixError("Couldn't reach SoundCloud");
+  }
+  if (!res.ok) {
+    throw new UnknownMixError(`SoundCloud lookup failed (${res.status})`);
+  }
+  const data = (await res.json()) as OEmbedResponse;
+  // Title sometimes comes back as "Title by Artist". Strip the trailing
+  // " by <author>" if we can confirm the author matches author_name — keeps
+  // the title clean without risking false positives on legitimate "by" titles.
+  const author = (data.author_name ?? "").trim();
+  let title = (data.title ?? "").trim();
+  if (author && title.toLowerCase().endsWith(` by ${author.toLowerCase()}`)) {
+    title = title.slice(0, title.length - (` by ${author}`.length)).trim();
+  }
+  return {
+    url,
+    title: title || "Untitled",
+    artist: author || "Unknown artist",
+    artworkUrl: data.thumbnail_url ?? null,
+  };
+}

--- a/apps/mobile/src/services/submissions.ts
+++ b/apps/mobile/src/services/submissions.ts
@@ -1,17 +1,29 @@
 import { supabase } from "@/lib/supabase";
 import { postgresToMixError } from "./errors";
 
-// Shape passed by the UI for each track slot. Maps to columns in `submissions`.
-export type TrackSelection = {
-  spotifyTrackId: string;
-  title: string;
-  artist: string;
-  artworkUrl: string | null;
-  isrc: string | null;
-  albumName: string | null;
-  durationMs: number | null;
-  popularity: number | null;
-};
+// Shape passed by the UI for each track slot. Discriminated by `source`;
+// each branch carries the fields needed to populate the matching DB columns.
+// A single submission row carries exactly one source's identity — the DB has
+// a check constraint that enforces this.
+export type TrackSelection =
+  | {
+      source: "spotify";
+      spotifyTrackId: string;
+      title: string;
+      artist: string;
+      artworkUrl: string | null;
+      isrc: string | null;
+      albumName: string | null;
+      durationMs: number | null;
+      popularity: number | null;
+    }
+  | {
+      source: "soundcloud";
+      soundcloudTrackUrl: string;
+      title: string;
+      artist: string;
+      artworkUrl: string | null;
+    };
 
 // One per slot. submissionId = null means "insert new"; otherwise "update".
 export type SubmissionDraft = {
@@ -28,16 +40,36 @@ export type SubmitRoundEntriesArgs = {
 
 function draftToColumns(draft: SubmissionDraft) {
   const { track } = draft;
-  return {
-    spotify_track_id: track.spotifyTrackId,
+  const common = {
     track_title: track.title,
     track_artist: track.artist,
     track_artwork_url: track.artworkUrl,
-    track_isrc: track.isrc ?? "",
-    track_album_name: track.albumName,
-    track_duration_ms: track.durationMs,
-    track_popularity: track.popularity,
     comment: draft.comment.trim() || null,
+  };
+  if (track.source === "spotify") {
+    return {
+      ...common,
+      track_source: "spotify" as const,
+      spotify_track_id: track.spotifyTrackId,
+      soundcloud_track_url: null,
+      track_isrc: track.isrc ?? "",
+      track_album_name: track.albumName,
+      track_duration_ms: track.durationMs,
+      track_popularity: track.popularity,
+    };
+  }
+  // SoundCloud: no ISRC / popularity / album-name / Spotify duration.
+  // track_isrc is NOT NULL in the schema, so we stash an empty string —
+  // matches the existing pattern for Spotify tracks missing an ISRC.
+  return {
+    ...common,
+    track_source: "soundcloud" as const,
+    spotify_track_id: null,
+    soundcloud_track_url: track.soundcloudTrackUrl,
+    track_isrc: "",
+    track_album_name: null,
+    track_duration_ms: null,
+    track_popularity: null,
   };
 }
 

--- a/apps/mobile/src/services/votes.ts
+++ b/apps/mobile/src/services/votes.ts
@@ -9,7 +9,9 @@ export type VotingSubmission = {
   track_title: string;
   track_artist: string;
   track_artwork_url: string | null;
+  track_source: "spotify" | "soundcloud";
   spotify_track_id: string | null;
+  soundcloud_track_url: string | null;
   track_isrc: string;
   comment: string | null;
   playlist_position: number | null;
@@ -31,12 +33,14 @@ export async function getRoundSubmissions(
   const { data, error } = await supabase
     .from("submissions")
     .select(
-      "id, user_id, track_title, track_artist, track_artwork_url, spotify_track_id, track_isrc, comment, playlist_position",
+      "id, user_id, track_title, track_artist, track_artwork_url, track_source, spotify_track_id, soundcloud_track_url, track_isrc, comment, playlist_position",
     )
     .eq("round_id", roundId)
     .order("playlist_position", { ascending: true, nullsFirst: false });
   if (error) throw postgresToMixError(error);
-  return data ?? [];
+  // Cast through unknown: `packages/db/types.ts` is stale and doesn't know
+  // about the new `track_source` / `soundcloud_track_url` columns yet.
+  return (data ?? []) as unknown as VotingSubmission[];
 }
 
 // Map of submissionId -> points the voter already allocated. Empty object if

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -189,8 +189,26 @@ function distributePoints(total, count, maxPerTrack) {
 // ─── Commands ─────────────────────────────────────────────────────────────────
 
 async function setupPlayers(env, args) {
-  const leagueId = args.league;
-  if (!leagueId) { console.error('Usage: setup-players --league <id>'); process.exit(1); }
+  let leagueId = args.league;
+  // Convenience: accept --season <id> and resolve to its league. Saves a
+  // separate lookup when you just got a season id from somewhere and want
+  // A/B/C added to whichever league it belongs to.
+  if (!leagueId && args.season) {
+    const seasonRes = await sb(
+      env,
+      `/rest/v1/seasons?id=eq.${args.season}&select=league_id&limit=1`,
+    );
+    leagueId = seasonRes.data?.[0]?.league_id;
+    if (!leagueId) {
+      console.error(`Could not find league for season ${args.season}`);
+      process.exit(1);
+    }
+    console.log(`Resolved season ${args.season} → league ${leagueId}`);
+  }
+  if (!leagueId) {
+    console.error('Usage: setup-players --league <id> | --season <id>');
+    process.exit(1);
+  }
 
   const state = loadState();
   if (!state.players) state.players = {};
@@ -561,6 +579,37 @@ async function registerPlayer(env, args) {
 
 // ─── Active round / rounds list ──────────────────────────────────────────────
 
+// Shared internal: same selection as activeRound below + the app's
+// getActiveRoundForLeague. Returns { season, round } or { season, round: null }
+// when the season exists but no rounds are open. Exits the process with a
+// useful message if the league has no active season — callers can assume the
+// returned shape is valid.
+async function getActiveSeasonAndRound(env, leagueId) {
+  const nowIso = new Date().toISOString();
+  const seasonRes = await sb(
+    env,
+    `/rest/v1/seasons?select=id,name&league_id=eq.${leagueId}&status=eq.active&limit=1`,
+  );
+  if (!seasonRes.ok) {
+    console.error('Season lookup failed:', seasonRes.data);
+    process.exit(1);
+  }
+  const season = seasonRes.data?.[0];
+  if (!season) {
+    console.error(`No active season for league ${leagueId}`);
+    process.exit(1);
+  }
+  const roundRes = await sb(
+    env,
+    `/rest/v1/rounds?select=id,round_number,prompt,submission_deadline_at,voting_deadline_at&season_id=eq.${season.id}&voting_deadline_at=gt.${encodeURIComponent(nowIso)}&order=round_number.asc&limit=1`,
+  );
+  if (!roundRes.ok) {
+    console.error('Round lookup failed:', roundRes.data);
+    process.exit(1);
+  }
+  return { season, round: roundRes.data?.[0] ?? null };
+}
+
 // Mirrors the app's `getActiveRoundForLeague` selection: first round in the
 // active season whose voting hasn't closed yet, ordered by round_number asc.
 // Prints round id, number, prompt, and both deadlines so you can see which
@@ -572,33 +621,7 @@ async function activeRound(env, args) {
     console.error('Usage: node scripts/test.mjs active-round --league <id>');
     process.exit(1);
   }
-  const nowIso = new Date().toISOString();
-
-  // Active season for the league.
-  const seasonRes = await sb(
-    env,
-    `/rest/v1/seasons?select=id,name&league_id=eq.${leagueId}&status=eq.active&limit=1`,
-  );
-  if (!seasonRes.ok) {
-    console.error('Season lookup failed:', seasonRes.data);
-    process.exit(1);
-  }
-  const season = seasonRes.data?.[0];
-  if (!season) {
-    console.log('No active season for league.');
-    return;
-  }
-
-  // First round whose voting is still open.
-  const roundRes = await sb(
-    env,
-    `/rest/v1/rounds?select=id,round_number,prompt,submission_deadline_at,voting_deadline_at&season_id=eq.${season.id}&voting_deadline_at=gt.${encodeURIComponent(nowIso)}&order=round_number.asc&limit=1`,
-  );
-  if (!roundRes.ok) {
-    console.error('Round lookup failed:', roundRes.data);
-    process.exit(1);
-  }
-  const round = roundRes.data?.[0];
+  const { season, round } = await getActiveSeasonAndRound(env, leagueId);
   console.log(`Active season: ${season.name} (${season.id})`);
   if (!round) {
     console.log('No active round (all rounds in this season have closed).');
@@ -610,6 +633,86 @@ async function activeRound(env, args) {
   console.log(`  prompt:                ${round.prompt}`);
   console.log(`  submission_deadline:   ${round.submission_deadline_at}`);
   console.log(`  voting_deadline:       ${round.voting_deadline_at}`);
+}
+
+// Run submit for players A, B, C against the league's active round. Convenience
+// wrapper — equivalent to looking up the active round and running submit three
+// times. Skips any player that errors so one missing player doesn't block the
+// rest of the batch.
+async function allSubmit(env, args) {
+  const leagueId = args.league;
+  if (!leagueId) {
+    console.error('Usage: all-submit --league <id>');
+    process.exit(1);
+  }
+  const { round } = await getActiveSeasonAndRound(env, leagueId);
+  if (!round) {
+    console.error('No active round to submit to.');
+    process.exit(1);
+  }
+  console.log(`Active round: R${round.round_number} (${round.id})`);
+  for (const key of CORE_PLAYERS) {
+    console.log(`\n[Player ${key}] submitting…`);
+    try {
+      await submitForPlayer(env, { player: key, round: round.id });
+    } catch (e) {
+      console.error(`  ✗ Player ${key} submit failed:`, e?.message ?? e);
+    }
+  }
+}
+
+// Run vote for players A, B, C against the league's active round.
+async function allVote(env, args) {
+  const leagueId = args.league;
+  if (!leagueId) {
+    console.error('Usage: all-vote --league <id>');
+    process.exit(1);
+  }
+  const { round } = await getActiveSeasonAndRound(env, leagueId);
+  if (!round) {
+    console.error('No active round to vote on.');
+    process.exit(1);
+  }
+  console.log(`Active round: R${round.round_number} (${round.id})`);
+  for (const key of CORE_PLAYERS) {
+    console.log(`\n[Player ${key}] voting…`);
+    try {
+      await voteForPlayer(env, { player: key, round: round.id });
+    } catch (e) {
+      console.error(`  ✗ Player ${key} vote failed:`, e?.message ?? e);
+    }
+  }
+}
+
+// Fetch the season's invite_token and print the mix:// join link. Same format
+// the league screen's Share button uses — paste it into the device's clipboard
+// and the deep-link handler in app/_layout.tsx will route to the join screen.
+async function inviteLink(env, args) {
+  const seasonId = args.season;
+  if (!seasonId) {
+    console.error('Usage: invite-link --season <id>');
+    process.exit(1);
+  }
+  const res = await sb(
+    env,
+    `/rest/v1/seasons?id=eq.${seasonId}&select=name,league_id,invite_token&limit=1`,
+  );
+  if (!res.ok) {
+    console.error('Season lookup failed:', res.data);
+    process.exit(1);
+  }
+  const season = res.data?.[0];
+  if (!season) {
+    console.error(`Season ${seasonId} not found.`);
+    process.exit(1);
+  }
+  if (!season.invite_token) {
+    console.error('Season has no invite_token.');
+    process.exit(1);
+  }
+  console.log(`Season:  ${season.name}`);
+  console.log(`League:  ${season.league_id}`);
+  console.log(`Invite:  mix://join?token=${season.invite_token}`);
 }
 
 // Dump all rounds in a season with their phase. Handy when "Previous round
@@ -651,26 +754,32 @@ const commands = {
   advance:            advanceRound,
   submit:             submitForPlayer,
   vote:               voteForPlayer,
+  'all-submit':       allSubmit,
+  'all-vote':         allVote,
   'close-voting':     closeVoting,
   'round-results':    roundResults,
   'active-round':     activeRound,
   rounds:             listRounds,
+  'invite-link':      inviteLink,
 };
 
 const fn = commands[command];
 if (!fn) {
   console.log('Usage: node scripts/test.mjs <command> [options]');
   console.log('');
-  console.log('  setup-players  --league <id>');
+  console.log('  setup-players  --league <id> | --season <id>');
   console.log('  create-user    --player <D|E>');
   console.log('  join           --player <A-E> --invite <url-or-token>');
   console.log('  advance        --round <id> [--subs-close <s>] [--vote-close <s>]');
   console.log('  submit         --player <A-E> --round <id>');
   console.log('  vote           --player <A-E> --round <id>');
+  console.log('  all-submit     --league <id>   (runs submit for A, B, C against active round)');
+  console.log('  all-vote       --league <id>   (runs vote   for A, B, C against active round)');
   console.log('  close-voting   [--round <id>]');
   console.log('  round-results  --round <id>');
   console.log('  active-round   --league <id>');
   console.log('  rounds         --season <id>');
+  console.log('  invite-link    --season <id>');
   process.exit(1);
 }
 

--- a/supabase/migrations/20260528202512_submissions_soundcloud.sql
+++ b/supabase/migrations/20260528202512_submissions_soundcloud.sql
@@ -1,0 +1,27 @@
+-- mix: SoundCloud submission support
+-- Adds `track_source` discriminator + `soundcloud_track_url` to submissions.
+-- A check constraint enforces that exactly one source-ID column is populated
+-- and that it matches the discriminator. Existing rows default to 'spotify',
+-- which is consistent with the current schema (every existing row has a
+-- non-null spotify_track_id).
+
+alter table public.submissions
+  add column track_source         text not null default 'spotify',
+  add column soundcloud_track_url text;
+
+alter table public.submissions
+  add constraint submissions_track_source_check
+    check (track_source in ('spotify', 'soundcloud'));
+
+-- Source/ID consistency: the discriminator picks exactly one ID column.
+-- Spotify rows must carry spotify_track_id and no SC URL; SoundCloud rows
+-- must carry a soundcloud_track_url and no Spotify ID. apple_music_track_id
+-- is intentionally untouched — it's currently unused and not part of the
+-- source discriminator yet.
+alter table public.submissions
+  add constraint submissions_source_id_consistency_check
+    check (
+      (track_source = 'spotify'    and spotify_track_id     is not null and soundcloud_track_url is null)
+      or
+      (track_source = 'soundcloud' and soundcloud_track_url is not null and spotify_track_id     is null)
+    );

--- a/supabase/migrations/20260528212247_submissions_unique_per_source.sql
+++ b/supabase/migrations/20260528212247_submissions_unique_per_source.sql
@@ -1,0 +1,34 @@
+-- mix: per-source uniqueness within a round.
+--
+-- The original `unique_track_per_round (round_id, track_isrc)` constraint
+-- assumed every submission has an ISRC — true for Spotify, false for
+-- SoundCloud (oEmbed doesn't expose one). The submission writer parks
+-- track_isrc = '' for SC tracks, so any two SC tracks in the same round
+-- collide on (round_id, '') and the second insert fails with
+-- unique_track_per_round.
+--
+-- New scheme: split the dedup rule by source.
+--   * Spotify: still dedup by ISRC (catches "same song from a different
+--     album" since one song can have multiple Spotify track ids but the
+--     ISRC is stable). Skip rows with empty ISRC — we can't dedup what
+--     we don't have, and we'd rather allow the submission than reject it.
+--   * SoundCloud: dedup by the canonical track URL.
+--
+-- The old constraint is dropped; everything is rewritten as partial
+-- unique indexes. Index names line up with what
+-- `postgresToMixError` expects so DuplicateTrackError is still raised.
+
+alter table public.submissions
+  drop constraint if exists unique_track_per_round;
+
+-- Spotify rows: same ISRC twice in a round is a duplicate. Empty ISRC
+-- rows are exempt (the API didn't give us one — better to accept the
+-- submission than to fail it).
+create unique index if not exists submissions_unique_spotify_isrc_per_round
+  on public.submissions (round_id, track_isrc)
+  where track_source = 'spotify' and track_isrc <> '';
+
+-- SoundCloud rows: same canonical URL twice in a round is a duplicate.
+create unique index if not exists submissions_unique_soundcloud_url_per_round
+  on public.submissions (round_id, soundcloud_track_url)
+  where track_source = 'soundcloud';


### PR DESCRIPTION
## Summary

- Adds first-class **SoundCloud** support to the submission picker and the playback layer (paste a SC track URL to submit it; auto-advance and seek work across both sources).
- Fixes a pile of playback bugs along the way (stale-closure that killed `playPlaylist`, scrubber flicker on drag, auto-advance never firing for Spotify natural-end, SC time label frozen during playback, etc.).
- Standard music-player **back-button UX**: <2s → previous track, ≥2s → restart current.
- Inline `[DEV] LEAGUES` switcher on the profile tab (replaces the unreliable `Alert`-based picker).
- Script niceties: `all-submit`, `all-vote`, `invite-link`, `setup-players --season`.

### DB migrations included

- `20260528202512_submissions_soundcloud.sql` — adds `track_source` discriminator + `soundcloud_track_url` column, with check constraints (exactly one source-ID populated, matching the discriminator).
- `20260528212247_submissions_unique_per_source.sql` — drops the blanket `unique_track_per_round` and replaces it with per-source partial unique indexes. The old constraint falsely collided two SC tracks via shared empty-string ISRC.

**Apply both with `supabase db push --include-all` before merging the app code.**

### Known gap (tracked separately)

Cross-source duplicate detection (same song submitted via Spotify and SC) is intentionally not handled — see #45. Soft-warning approach is the post-MVP plan.

## Test plan

- [ ] Migration applies cleanly on remote.
- [ ] Paste a SoundCloud track URL (canonical `soundcloud.com/...` AND short `on.soundcloud.com/...`) → preview row shows title/artist/artwork; no Spotify garbage results.
- [ ] Plain text query still returns Spotify results.
- [ ] Submit a SoundCloud track → row appears in voting view, plays back correctly.
- [ ] Submit two SC tracks (different URLs) → both succeed; submit same URL twice → second blocked with "Someone already submitted this track for this round."
- [ ] SC playback: scrub → time label advances from drop position (not frozen).
- [ ] Auto-advance Spotify → SC → time ticks from 0; auto-advance SC → Spotify → same.
- [ ] Auto-advance stops at end of playlist (no loop, no error).
- [ ] Back button: ≥2s in restarts current track; <2s in goes to previous.
- [ ] Voting row tap zone: artwork/title taps play track; vote arrows and comment button don't.
- [ ] Current track shows `▶` in playlist + voting screens.
- [ ] `[DEV] LEAGUES` switcher swaps active league.

🤖 Generated with [Claude Code](https://claude.com/claude-code)