### PR TITLE
fix(ui): italic round titles, remove avatar circles, fix halo tint drift

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -8,6 +8,7 @@ import {
   Fraunces_500Medium,
   Fraunces_500Medium_Italic,
   Fraunces_700Bold,
+  Fraunces_700Bold_Italic,
 } from "@expo-google-fonts/fraunces";
 import {
   InterTight_400Regular,
@@ -85,6 +86,7 @@ export default function RootLayout() {
     Fraunces_500Medium,
     Fraunces_500Medium_Italic,
     Fraunces_700Bold,
+    Fraunces_700Bold_Italic,
     InterTight_400Regular,
     InterTight_500Medium,
     InterTight_600SemiBold,

--- a/apps/mobile/src/app/ui-preview/index.tsx
+++ b/apps/mobile/src/app/ui-preview/index.tsx
@@ -133,11 +133,6 @@ const SEASONS: Array<{
   },
 ];
 
-const PLAYERS = [
-  { id: "nia", displayName: "Nia" },
-  { id: "jules", displayName: "Jules" },
-  { id: "theo", displayName: "Theo" },
-];
 
 // ── Screen ───────────────────────────────────────────────────────────
 
@@ -201,7 +196,6 @@ export default function V1ArchiveHome() {
           <PageHeader
             leagueTag="Ghost Mall FM"
             title="Home"
-            participants={PLAYERS}
           />
 
           <HeroRoundCard

--- a/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
+++ b/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
@@ -464,8 +464,7 @@ const styles = StyleSheet.create({
     flexWrap: "wrap",
   },
   titleText: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: "italic",
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 28,
     lineHeight: 32,
     letterSpacing: -0.6,

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -3362,8 +3362,7 @@ const styles = StyleSheet.create({
     // into a hard rectangle.
   },
   heroTitle: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: "italic",
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 74,
     lineHeight: 80,
     letterSpacing: -3,
@@ -3554,8 +3553,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   voteTitleOnHero: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: "italic",
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 28,
     lineHeight: 32,
     letterSpacing: -0.6,
@@ -3563,8 +3561,7 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   voteTitle: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: "italic",
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 28,
     lineHeight: 32,
     letterSpacing: -0.6,
@@ -3884,8 +3881,7 @@ const styles = StyleSheet.create({
     flexWrap: "nowrap",
   },
   resultsTitle: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: "italic",
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 56,
     lineHeight: 54,
     letterSpacing: -2.2,

--- a/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
@@ -28,7 +28,6 @@ import { useSession } from '@/context/SessionContext';
 import { useLeague as useLeagueContext } from '@/context/LeagueContext';
 
 import { useLeague } from '@/queries/useLeague';
-import { useLeagueMembers } from '@/queries/useLeagueMembers';
 import { useActiveSeasonForLeague } from '@/queries/useActiveSeasonForLeague';
 import { useActiveRoundForLeague } from '@/queries/useActiveRoundForLeague';
 import { useRound } from '@/queries/useRound';
@@ -157,7 +156,6 @@ function HomeTabContent({
   }, [queryClient]);
 
   const { data: league } = useLeague(leagueId);
-  const { data: members = [] } = useLeagueMembers(leagueId);
   const { data: activeSeason } = useActiveSeasonForLeague(leagueId);
   const { data: activeRoundLookup } = useActiveRoundForLeague(leagueId);
   const activeRoundId = activeRoundLookup?.round?.roundId;
@@ -262,16 +260,6 @@ function HomeTabContent({
     userId,
   ]);
 
-  // Header participants (drop spectators per CLAUDE.md guidance for the
-  // avatar stack).
-  const participants = useMemo(
-    () =>
-      members
-        .filter((m) => m.role !== 'spectator')
-        .map((m) => ({ id: m.user_id, displayName: m.display_name })),
-    [members],
-  );
-
   // Hero card data.
   const hero = useMemo(() => {
     if (!round) return null;
@@ -366,7 +354,6 @@ function HomeTabContent({
           <PageHeader
             leagueTag={league?.name}
             title="Home"
-            participants={participants}
             trailing={commissionerTrailing}
           />
 
@@ -551,10 +538,10 @@ const styles = StyleSheet.create({
   },
   roundTitleTagline: {
     fontFamily: THEME.fonts.serifItalic,
-    fontSize: 14,
+    fontSize: 17,
     color: THEME.ink,
     // Raise above HaloText's spill so the blur doesn't capture this label.
-    zIndex: 1,
+    zIndex: 2,
   },
   roundTitleHaloWrap: {
     flexDirection: 'row',
@@ -565,8 +552,7 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
   },
   roundTitleText: {
-    fontFamily: THEME.fonts.serifBold,
-    fontStyle: 'italic',
+    fontFamily: THEME.fonts.serifBoldItalic,
     fontSize: 52,
     lineHeight: 56,
     letterSpacing: -2.2,

--- a/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
@@ -535,6 +535,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
     gap: 4,
     paddingHorizontal: 22,
+    overflow: 'visible',
   },
   roundTitleTagline: {
     fontFamily: THEME.fonts.serifItalic,
@@ -550,6 +551,7 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     paddingHorizontal: 18,
     paddingVertical: 14,
+    overflow: 'visible',
   },
   roundTitleText: {
     fontFamily: THEME.fonts.serifBoldItalic,

--- a/apps/mobile/src/ui/FittedChromeTitle.tsx
+++ b/apps/mobile/src/ui/FittedChromeTitle.tsx
@@ -119,7 +119,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     overflow: "visible",
-    paddingHorizontal: 8,
+    paddingLeft: 8,
+    paddingRight: 20,
     paddingVertical: 3,
   },
   lineText: {

--- a/apps/mobile/src/ui/FittedChromeTitle.tsx
+++ b/apps/mobile/src/ui/FittedChromeTitle.tsx
@@ -119,14 +119,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     overflow: "visible",
-    paddingLeft: 8,
-    paddingRight: 20,
+    paddingHorizontal: 8,
     paddingVertical: 3,
   },
   lineText: {
     flexShrink: 1,
     minWidth: 0,
-    width: "auto",
+    width: "100%",
   },
   accent: {
     flexShrink: 0,

--- a/apps/mobile/src/ui/HaloText.tsx
+++ b/apps/mobile/src/ui/HaloText.tsx
@@ -54,7 +54,7 @@ export function HaloText({
   innerCoreStop = 0.35,
   outerCoreOpacity = 0.85,
   innerCoreOpacity = 1,
-  tint = "default",
+  tint = "light",
 }: HaloTextProps) {
   return (
     <View style={style}>

--- a/apps/mobile/src/ui/HaloText.tsx
+++ b/apps/mobile/src/ui/HaloText.tsx
@@ -57,7 +57,7 @@ export function HaloText({
   tint = "light",
 }: HaloTextProps) {
   return (
-    <View style={style}>
+    <View style={[style, { overflow: 'visible' }]}>
       <View
         pointerEvents="none"
         style={{

--- a/apps/mobile/src/ui/PageHeader.tsx
+++ b/apps/mobile/src/ui/PageHeader.tsx
@@ -5,34 +5,26 @@
 import type { ReactNode } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { THEME } from "@/ui/theme";
-import {
-  AvatarStack,
-  type AvatarParticipant,
-} from "@/ui/sections/AvatarStack";
 
 export type PageHeaderProps = {
   leagueTag?: string;
   title: string;
-  participants?: AvatarParticipant[];
   trailing?: ReactNode;
 };
 
 export function PageHeader({
   leagueTag,
   title,
-  participants,
   trailing,
 }: PageHeaderProps) {
-  const hasParticipants = participants && participants.length > 0;
   return (
     <View style={styles.header}>
       <View style={styles.left}>
         {leagueTag ? <Text style={styles.leagueTag}>{leagueTag}</Text> : null}
-        <Text style={[styles.pageTitle, leagueTag ? styles.pageTitleSpacing : null]}>
+        <Text numberOfLines={1} style={[styles.pageTitle, leagueTag ? styles.pageTitleSpacing : null]}>
           {title}
         </Text>
       </View>
-      {hasParticipants ? <AvatarStack participants={participants!} /> : null}
       {trailing}
     </View>
   );
@@ -52,7 +44,6 @@ const styles = StyleSheet.create({
   },
   pageTitle: {
     ...THEME.text.homePageTitle,
-    fontStyle: "italic",
   },
   pageTitleSpacing: {
     marginTop: 4,

--- a/apps/mobile/src/ui/theme/bubblegum.ts
+++ b/apps/mobile/src/ui/theme/bubblegum.ts
@@ -13,6 +13,7 @@ const fonts = {
   serifMedium: "Fraunces_500Medium",
   serifMediumItalic: "Fraunces_500Medium_Italic",
   serifBold: "Fraunces_700Bold",
+  serifBoldItalic: "Fraunces_700Bold_Italic",
   sans: "InterTight_400Regular",
   sansMedium: "InterTight_500Medium",
   sansSemi: "InterTight_600SemiBold",
@@ -80,8 +81,7 @@ export const BUBBLEGUM_THEME: MixTheme = {
       color: colors.ink,
     },
     homePageTitle: {
-      fontFamily: fonts.serifBold,
-      fontStyle: "italic",
+      fontFamily: fonts.serifBoldItalic,
       fontSize: 48,
       lineHeight: 50,
       letterSpacing: -1.8,

--- a/apps/mobile/src/ui/theme/disco.ts
+++ b/apps/mobile/src/ui/theme/disco.ts
@@ -6,6 +6,7 @@ const fonts = {
   serifMedium: "Fraunces_500Medium",
   serifMediumItalic: "Fraunces_500Medium_Italic",
   serifBold: "Fraunces_700Bold",
+  serifBoldItalic: "Fraunces_700Bold_Italic",
   sans: "InterTight_400Regular",
   sansMedium: "InterTight_500Medium",
   sansSemi: "InterTight_600SemiBold",

--- a/apps/mobile/src/ui/theme/types.ts
+++ b/apps/mobile/src/ui/theme/types.ts
@@ -61,6 +61,7 @@ export type MixTheme = {
     serifMedium: string;
     serifMediumItalic: string;
     serifBold: string;
+    serifBoldItalic: string;
     sans: string;
     sansMedium: string;
     sansSemi: string;


### PR DESCRIPTION
## Summary

- **Italic round titles**: `fontStyle: 'italic'` is silently ignored on iOS for custom fonts — the OS won't synthesize italic. Loaded `Fraunces_700Bold_Italic` and switched all round prompt display headlines (home hero, voting, results, playlist, submissions) to use `serifBoldItalic` directly.
- **Remove avatar circles**: Dropped the league member avatar stack from `PageHeader` — removes the `useLeagueMembers` fetch, the `AvatarStack` component, and the `participants` prop. Commissioner season/round buttons are untouched.
- **Fix dark shadow on device**: `HaloText` was using `tint="default"` which maps to a darkening vibrancy material on real iOS hardware (sim renders it lighter via the macOS stack). Changed default to `"light"` for consistent frosted-glass look across both.
- **Home title no longer wraps**: Added `numberOfLines={1}` to `PageHeader` title — font metrics differ slightly between sim and device, causing "Home" to wrap on sim.
- **"this sounds like" tagline**: Bumped `fontSize` 14→17 and `zIndex` 1→2 so it reads clearly above the halo blur bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)