### PR TITLE
Interactive Liquid Glass on the now-playing pill

### DIFF
--- a/apps/mobile/src/ui/playback/NowPlayingPill.tsx
+++ b/apps/mobile/src/ui/playback/NowPlayingPill.tsx
@@ -62,7 +62,8 @@ export function NowPlayingPill({
     <View style={[styles.wrap, style]}>
       <GlassSurface
         glassEffectStyle="clear"
-        fallbackBlurIntensity={45}
+        interactive
+        fallbackBlurIntensity={65}
         style={styles.pill}
       >
         <Pressable


### PR DESCRIPTION
## Interactive Liquid Glass on the now-playing pill

Follow-up to #48 (merged). One focused change to the pill's glass.

Enables `isInteractive` on the now-playing pill's `GlassSurface` so the real iOS 26 Liquid Glass picks up **live edge lensing/refraction** and reacts to touch, instead of reading like flat frost. Keeps `glassEffectStyle="clear"` (lowest blur, retains the warping) and bumps the BlurView fallback intensity 45 → 65 so non-iOS-26 devices keep the title legible.

### Context on why this is the chosen config
`UIGlassEffect` (what `expo-glass-effect` wraps) exposes only:
- `style`: `clear` / `regular` (no `thin`/`thick`, **no blur-radius knob**)
- `tintColor`
- `isInteractive`

There is no continuous blur control at the OS level, so `clear + interactive` is the lowest-blur-with-warping combination available — confirmed against the native module source.

### Verification
- `pnpm --filter @mix/mobile type-check` passes.
- `interactive` look confirmed on-device (iPhone 17 Pro Max, iOS 26.5) via reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
