### PR TITLE
feat(submissions): 27-min track duration limit with animated rejection UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,40 @@ deliberately rather than folding everything into services.
 
 ---
 
+## Installing and upgrading packages
+
+This is a pnpm monorepo with an Expo SDK mobile app. The Expo SDK pins tested
+versions of every native module via `bundledNativeModules.json`. Installing a
+native dep outside that matrix breaks the iOS/Android build (wrong ABI,
+missing codegen symbols, etc.).
+
+**Rule: always use `expo install` for any package that has a native iOS/Android
+component. Never use `pnpm add` directly for these.**
+
+```
+# correct
+pnpm --filter @mix/mobile exec npx expo install <pkg>
+
+# wrong — bypasses Expo's version matrix
+pnpm --filter @mix/mobile add <pkg>
+pnpm add <pkg>
+```
+
+Pure JS packages (no native module) may use `pnpm add` as normal.
+
+If unsure whether a package is native, default to `expo install`.
+
+After installing a native package, pod install is required before building:
+```
+pnpm --filter @mix/mobile exec pod install --project-directory=ios
+```
+
+Root `package.json` carries a `pnpm.overrides` block that enforces Expo SDK 54
+version ceilings on known-problematic native deps. When upgrading the Expo SDK,
+update those overrides to match the new SDK's pinned versions.
+
+---
+
 ## Known tech debt tracked against the pattern
 
 - `packages/db/types.ts` is stale; some services cast through `unknown`.

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -386,9 +386,7 @@ function TrackRow({
 // chrome glyph accents, baby-pink pick cards. See `ui/theme/bubblegum.ts`
 // for the token spec; matches Claude Design's Submit screen mock.
 
-// DEV: 5 s so any track triggers the limit during testing.
-// PROD: 27 minutes.
-const MAX_TRACK_DURATION_MS = __DEV__ ? 5_000 : 27 * 60 * 1000;
+const MAX_TRACK_DURATION_MS = 27 * 60 * 1000;
 
 function TrackLimitBanner({
   durationMs,

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -13,6 +13,7 @@ import {
   TextInput,
   Alert,
   Image,
+  Animated,
   LayoutAnimation,
   UIManager,
   useWindowDimensions,
@@ -166,6 +167,7 @@ type DraftSubmission = {
   searchResults: PickedTrack[];
   isSearching: boolean;
   isEditingTrack: boolean;
+  trackLimitError: { durationMs: number } | null;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -177,6 +179,13 @@ function formatDeadline(iso: string) {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
 function submissionToTrack(submission: Submission): PickedTrack {
@@ -230,6 +239,7 @@ function createDraftSubmission(
     // placeholders. The first empty slot auto-expands so the editor is ready
     // without an extra tap.
     isEditingTrack: existing ? false : autoExpand,
+    trackLimitError: null,
   };
 }
 
@@ -376,6 +386,68 @@ function TrackRow({
 // chrome glyph accents, baby-pink pick cards. See `ui/theme/bubblegum.ts`
 // for the token spec; matches Claude Design's Submit screen mock.
 
+// DEV: 5 s so any track triggers the limit during testing.
+// PROD: 27 minutes.
+const MAX_TRACK_DURATION_MS = __DEV__ ? 5_000 : 27 * 60 * 1000;
+
+function TrackLimitBanner({
+  durationMs,
+  onDismiss,
+}: {
+  durationMs: number;
+  onDismiss: () => void;
+}) {
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 90,
+      useNativeDriver: true,
+    }).start();
+  }, [opacity]);
+
+  const handleDismiss = () => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 40,
+      useNativeDriver: true,
+    }).start(() => {
+      LayoutAnimation.configureNext({
+        duration: 100,
+        update: { type: "easeInEaseOut" },
+        delete: { type: "easeInEaseOut", property: "opacity" },
+      });
+      onDismiss();
+    });
+  };
+
+  return (
+    <Animated.View style={[styles.trackLimitBanner, { opacity }]}>
+      <View style={styles.trackLimitBannerRow}>
+        <View style={styles.trackLimitBannerLeft}>
+          <View style={styles.trackLimitTagRow}>
+            <Text style={styles.trackLimitTag}>TOO LONG</Text>
+            <Text style={styles.trackLimitDuration}>
+              {formatDurationMs(durationMs)}
+            </Text>
+          </View>
+          <Text style={styles.trackLimitHint}>
+            max {formatDurationMs(MAX_TRACK_DURATION_MS)} · try a shorter track
+          </Text>
+        </View>
+        <TouchableOpacity
+          onPress={handleDismiss}
+          hitSlop={12}
+          style={styles.trackLimitDismiss}
+        >
+          <Text style={styles.trackLimitDismissGlyph}>×</Text>
+        </TouchableOpacity>
+      </View>
+    </Animated.View>
+  );
+}
+
 function SubmissionPhase({
   round,
   userId,
@@ -520,6 +592,7 @@ function SubmissionPhase({
   const updateSearchInput = (slotIndex: number, searchInput: string) => {
     setSearchState(slotIndex, {
       searchInput,
+      trackLimitError: null,
       ...(searchInput.trim()
         ? {}
         : { searchResults: [], isSearching: false }),
@@ -527,6 +600,18 @@ function SubmissionPhase({
   };
 
   const selectTrack = (slotIndex: number, track: PickedTrack) => {
+    if (track.source === "spotify" && track.data.duration_ms > MAX_TRACK_DURATION_MS) {
+      LayoutAnimation.configureNext({
+        duration: 110,
+        create: { type: "easeInEaseOut", property: "opacity" },
+        update: { type: "easeInEaseOut" },
+      });
+      setSearchState(slotIndex, {
+        trackLimitError: { durationMs: track.data.duration_ms },
+      });
+      return;
+    }
+
     const incomingId = pickedId(track);
     const duplicateSlot = drafts.findIndex(
       (draft, i) =>
@@ -580,6 +665,7 @@ function SubmissionPhase({
       searchInput: "",
       searchResults: [],
       isSearching: false,
+      trackLimitError: null,
     });
   };
 
@@ -772,6 +858,13 @@ function SubmissionPhase({
                   />
                 </View>
               </ChromeBorder>
+
+              {draft.trackLimitError && (
+                <TrackLimitBanner
+                  durationMs={draft.trackLimitError.durationMs}
+                  onDismiss={() => setSearchState(index, { trackLimitError: null })}
+                />
+              )}
 
               {draft.isSearching && (
                 <ActivityIndicator
@@ -3520,6 +3613,55 @@ const styles = StyleSheet.create({
     fontFamily: THEME.fonts.sansMedium,
     fontSize: 12,
     color: THEME.muted,
+  },
+
+  // ─── Track duration limit rejection banner ────────────────────────────────
+  trackLimitBanner: {
+    backgroundColor: THEME.ink,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#C4FF3D",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  trackLimitBannerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  trackLimitBannerLeft: {
+    flex: 1,
+    gap: 4,
+  },
+  trackLimitTagRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  trackLimitTag: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 9,
+    letterSpacing: 1.8,
+    color: "#C4FF3D",
+  },
+  trackLimitDuration: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 12,
+    color: "#FFD9EC",
+  },
+  trackLimitHint: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 11,
+    color: "rgba(255,217,236,0.55)",
+  },
+  trackLimitDismiss: {
+    paddingLeft: 12,
+  },
+  trackLimitDismissGlyph: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 18,
+    color: "rgba(255,217,236,0.5)",
+    lineHeight: 20,
   },
 
   // ─── Voting hero overlay (title + meta + buttons under the faded image) ──

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "android": "pnpm --filter @mix/mobile android",
     "ios": "pnpm --filter @mix/mobile ios",
     "ios:sim": "pnpm --filter @mix/mobile ios:sim",
+    "ios:device": "pnpm --filter @mix/mobile ios:device",
+    "vic": "pnpm --filter @mix/mobile vic",
     "setup": "pnpm install && pnpm --filter @mix/mobile prebuild"
   },
   "devDependencies": {
@@ -27,5 +29,10 @@
     "pnpm": ">=9.0.0"
   },
   "packageManager": "pnpm@10.17.0",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "pnpm": {
+    "overrides": {
+      "react-native-svg": "~15.12.1"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Rejects Spotify submissions longer than 27 minutes at track-selection time (before the user can submit)
- `MAX_TRACK_DURATION_MS` constant at the top of `SubmissionPhase` — set to 5 s in `__DEV__` for easy testing, 27 min in prod
- Animated `TrackLimitBanner`: fades in (90 ms) above the search results, content slides down on appear; 40 ms fade-out then slides up on dismiss; lime accent border (`#C4FF3D`) as the warning color; dismissable with ×
- SoundCloud submissions currently bypass the check (oEmbed doesn't expose duration) — follow-up PR will add an ephemeral Widget probe to cover that case
- Pins `react-native-svg` to `~15.12.1` via `pnpm.overrides` to prevent Expo SDK 54 ABI mismatch from transitive upgrades
- Updates `CLAUDE.md` to mandate `expo install` for native deps and document the overrides block

## Test plan

- [ ] In DEV: search Spotify and tap any track — banner appears with "TOO LONG · {duration}", slides content down, dismisses cleanly
- [ ] Dismiss × fades out (40 ms) then content slides up
- [ ] Typing in the search box after a rejection clears the banner
- [ ] Tapping EDIT on a saved slot clears the banner
- [ ] In PROD build: tracks under 27 min submit normally; confirm the constant is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)