### PR TITLE
feat(submissions): enforce duration limit on SoundCloud picks

### DIFF
--- a/apps/mobile/src/playback/useSoundCloudDurationProbe.tsx
+++ b/apps/mobile/src/playback/useSoundCloudDurationProbe.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useRef, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { WebView, type WebViewMessageEvent } from "react-native-webview";
+
+// SoundCloud's oEmbed endpoint (used by resolveSoundCloudTrack) doesn't expose
+// track duration, so we can't length-check a SoundCloud pick the way we do a
+// Spotify one. This hook spins up an ephemeral hidden WebView that loads the
+// track into the SoundCloud Widget just long enough to read getDuration() on
+// the READY event, then unmounts. It's the only no-API-key way to learn a
+// SoundCloud track's length — DJ sets routinely run over an hour, so we have
+// to gate them somehow.
+//
+// Usage:
+//   const { probeDuration, probeView } = useSoundCloudDurationProbe();
+//   render {probeView} somewhere; then `const ms = await probeDuration(url)`.
+// Resolves the duration in ms, or null if the probe fails/times out (caller
+// should fail open — a flaky probe shouldn't block a legitimate submission).
+
+const PROBE_TIMEOUT_MS = 8000;
+
+function probeHtml(trackUrl: string): string {
+  const src =
+    "https://w.soundcloud.com/player/?url=" +
+    encodeURIComponent(trackUrl) +
+    "&auto_play=false&visual=false&buying=false&liking=false" +
+    "&download=false&sharing=false&show_comments=false&show_related=false";
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;">
+<iframe id="p" src="${src}" width="1" height="1" frameborder="no" allow="autoplay"></iframe>
+<script src="https://w.soundcloud.com/player/api.js"></script>
+<script>
+  var widget = SC.Widget(document.getElementById('p'));
+  function rn(d){ window.ReactNativeWebView.postMessage(String(d)); }
+  widget.bind(SC.Widget.Events.READY, function(){
+    widget.getDuration(function(d){ rn(d); });
+  });
+  widget.bind(SC.Widget.Events.ERROR, function(){ rn('error'); });
+</script>
+</body>
+</html>`;
+}
+
+export function useSoundCloudDurationProbe() {
+  const [url, setUrl] = useState<string | null>(null);
+  const resolveRef = useRef<((ms: number | null) => void) | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const finish = useCallback((ms: number | null) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const resolve = resolveRef.current;
+    resolveRef.current = null;
+    setUrl(null);
+    resolve?.(ms);
+  }, []);
+
+  const probeDuration = useCallback(
+    (trackUrl: string) => {
+      // Cancel any in-flight probe (resolves its promise as null) before
+      // starting a new one — only one probe runs at a time.
+      if (resolveRef.current) finish(null);
+      return new Promise<number | null>((resolve) => {
+        resolveRef.current = resolve;
+        timerRef.current = setTimeout(() => finish(null), PROBE_TIMEOUT_MS);
+        setUrl(trackUrl);
+      });
+    },
+    [finish],
+  );
+
+  const onMessage = useCallback(
+    (e: WebViewMessageEvent) => {
+      const ms = Number(e.nativeEvent.data);
+      finish(Number.isFinite(ms) && ms > 0 ? ms : null);
+    },
+    [finish],
+  );
+
+  // `key={url}` forces a fresh WebView per probe so the READY event fires for
+  // the newly-loaded track rather than reusing a stale widget instance.
+  const probeView = url ? (
+    <View style={styles.hidden} pointerEvents="none">
+      <WebView
+        key={url}
+        source={{ html: probeHtml(url), baseUrl: "https://soundcloud.com" }}
+        onMessage={onMessage}
+        javaScriptEnabled
+        originWhitelist={["*"]}
+        onError={() => finish(null)}
+        onHttpError={() => finish(null)}
+      />
+    </View>
+  ) : null;
+
+  return { probeDuration, probeView };
+}
+
+const styles = StyleSheet.create({
+  hidden: {
+    position: "absolute",
+    width: 1,
+    height: 1,
+    opacity: 0,
+  },
+});

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -79,6 +79,7 @@ import { useTabBarBottomInset } from "@/ui/hooks/useTabBarBottomInset";
 import { derivePhase, formatPhaseCountdown } from "@/lib/utils/phase";
 import { roundCoverKey } from "@/lib/utils/coverKey";
 import { usePlayback, type PlaylistTrack } from "@/playback/PlaybackContext";
+import { useSoundCloudDurationProbe } from "@/playback/useSoundCloudDurationProbe";
 import { normalizeSpotifyTrackUri } from "@/lib/spotifyTrackUri";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -167,6 +168,7 @@ type DraftSubmission = {
   searchResults: PickedTrack[];
   isSearching: boolean;
   isEditingTrack: boolean;
+  isCheckingLength: boolean;
   trackLimitError: { durationMs: number } | null;
 };
 
@@ -239,6 +241,7 @@ function createDraftSubmission(
     // placeholders. The first empty slot auto-expands so the editor is ready
     // without an extra tap.
     isEditingTrack: existing ? false : autoExpand,
+    isCheckingLength: false,
     trackLimitError: null,
   };
 }
@@ -461,6 +464,7 @@ function SubmissionPhase({
   const [drafts, setDrafts] = useState<DraftSubmission[]>([]);
   const searchRequestIds = useRef<Record<number, number>>({});
   const submitMutation = useSubmitRoundEntries();
+  const { probeDuration, probeView } = useSoundCloudDurationProbe();
   const submitting = submitMutation.isPending;
 
   const baselineDrafts = useMemo(() => {
@@ -597,19 +601,18 @@ function SubmissionPhase({
     });
   };
 
-  const selectTrack = (slotIndex: number, track: PickedTrack) => {
-    if (track.source === "spotify" && track.data.duration_ms > MAX_TRACK_DURATION_MS) {
-      LayoutAnimation.configureNext({
-        duration: 110,
-        create: { type: "easeInEaseOut", property: "opacity" },
-        update: { type: "easeInEaseOut" },
-      });
-      setSearchState(slotIndex, {
-        trackLimitError: { durationMs: track.data.duration_ms },
-      });
-      return;
-    }
+  const rejectTooLong = (slotIndex: number, durationMs: number) => {
+    LayoutAnimation.configureNext({
+      duration: 110,
+      create: { type: "easeInEaseOut", property: "opacity" },
+      update: { type: "easeInEaseOut" },
+    });
+    setSearchState(slotIndex, { trackLimitError: { durationMs } });
+  };
 
+  // Commit the track, close this editor, and progressively open the
+  // immediately-next empty slot as the new editor.
+  const commitTrack = (slotIndex: number, track: PickedTrack) => {
     const incomingId = pickedId(track);
     const duplicateSlot = drafts.findIndex(
       (draft, i) =>
@@ -625,8 +628,6 @@ function SubmissionPhase({
       return;
     }
 
-    // Commit the track, close this editor, and progressively open the
-    // immediately-next empty slot as the new editor.
     setDrafts((prev) => {
       const next = prev.map((draft, i) =>
         i === slotIndex
@@ -650,6 +651,31 @@ function SubmissionPhase({
       }
       return next;
     });
+  };
+
+  const selectTrack = async (slotIndex: number, track: PickedTrack) => {
+    // Spotify ships duration in the search payload, so the check is instant.
+    if (track.source === "spotify") {
+      if (track.data.duration_ms > MAX_TRACK_DURATION_MS) {
+        rejectTooLong(slotIndex, track.data.duration_ms);
+        return;
+      }
+      commitTrack(slotIndex, track);
+      return;
+    }
+
+    // SoundCloud has no duration in its metadata — probe it via a hidden
+    // widget. Guard against double-taps while a probe is already running.
+    if (drafts[slotIndex]?.isCheckingLength) return;
+    setSearchState(slotIndex, { isCheckingLength: true });
+    const durationMs = await probeDuration(track.data.url);
+    setSearchState(slotIndex, { isCheckingLength: false });
+    // Fail open: a null probe (timeout/error) shouldn't block a submission.
+    if (durationMs != null && durationMs > MAX_TRACK_DURATION_MS) {
+      rejectTooLong(slotIndex, durationMs);
+      return;
+    }
+    commitTrack(slotIndex, track);
   };
 
   // EDIT button on a filled slot reuses this: clears the track AND flips
@@ -857,6 +883,15 @@ function SubmissionPhase({
                 </View>
               </ChromeBorder>
 
+              {draft.isCheckingLength && (
+                <View style={styles.checkingLengthRow}>
+                  <ActivityIndicator color={THEME.muted} size="small" />
+                  <Text style={styles.checkingLengthText}>
+                    Checking length…
+                  </Text>
+                </View>
+              )}
+
               {draft.trackLimitError && (
                 <TrackLimitBanner
                   durationMs={draft.trackLimitError.durationMs}
@@ -939,6 +974,9 @@ function SubmissionPhase({
         disabled={!canSubmit}
         loading={submitting}
       />
+
+      {/* Hidden ephemeral WebView that reads a SoundCloud track's duration. */}
+      {probeView}
     </View>
   );
 }
@@ -3660,6 +3698,18 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: "rgba(255,217,236,0.5)",
     lineHeight: 20,
+  },
+  // Shown while an ephemeral widget probes a SoundCloud track's duration.
+  checkingLengthRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 4,
+  },
+  checkingLengthText: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 12,
+    color: THEME.muted,
   },
 
   // ─── Voting hero overlay (title + meta + buttons under the faded image) ──


### PR DESCRIPTION
## Summary

Extends the 27-minute track duration limit (PR #50) to **SoundCloud** submissions.

SoundCloud's oEmbed endpoint exposes no duration, so we can't length-check a pick the way we do for Spotify (whose duration ships in the search payload). DJ sets routinely run over an hour, so we needed a way to catch them.

**Approach:** when a user taps a SoundCloud result, a hidden ephemeral WebView loads the track into the SoundCloud Widget, reads `getDuration()` on the `READY` event, then unmounts. No API key required.

- New hook `useSoundCloudDurationProbe()` → `{ probeDuration, probeView }`
- Reuses the existing `TrackLimitBanner` rejection UI
- Shows a "Checking length…" spinner during the probe
- **Fails open** on timeout (8s) or error — a flaky probe never blocks a legitimate submission
- `selectTrack` refactored into `rejectTooLong` + `commitTrack` helpers; Spotify path unchanged

## Test plan

- [x] Short SoundCloud track → brief check, commits normally
- [x] Long DJ set (>27 min) → "TOO LONG" banner with real duration
- [x] Spotify picks behave exactly as before

No native rebuild needed — `react-native-webview` is already in the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)