### PR TITLE
fix(round): keep focused input above keyboard on submission screen

### DIFF
--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -40,6 +40,7 @@ if (
 import { Stack, useRouter, useFocusEffect } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Wallpaper } from "@/ui/Wallpaper";
+import { KeyboardScroll } from "@/components/KeyboardScroll";
 import { ChromeText } from "@/ui/ChromeText";
 import { ChromeBorder } from "@/ui/ChromeBorder";
 import { ChromeButton } from "@/ui/ChromeButton";
@@ -2710,39 +2711,35 @@ export function RoundScreen({
             ),
           }}
         />
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          keyboardVerticalOffset={88}
-        >
-          <Wallpaper>
-            <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
-              <ScrollView
-                ref={scrollViewRef}
-                contentContainerStyle={[
-                  styles.submitScroll,
-                  { paddingBottom: bottomInset + 24 },
-                ]}
-                keyboardShouldPersistTaps="handled"
-                refreshControl={
-                  <RefreshControl
-                    refreshing={refreshing}
-                    onRefresh={onRefresh}
-                    tintColor={THEME.ink}
-                  />
-                }
-              >
-                <SubmissionsHero round={round} countdown={countdown} />
-                <SubmissionPhase
-                  round={round}
-                  userId={userId}
-                  mySubmissions={mySubmissions}
-                  onSubmitted={() => router.back()}
+        <Wallpaper>
+          <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
+            <KeyboardScroll
+              contentContainerStyle={[
+                styles.submitScroll,
+                { paddingBottom: bottomInset + 36 },
+              ]}
+              // Gap kept between the keyboard and the focused field. Bump this
+              // if a field still feels too close to the keyboard.
+              extraScrollHeight={48}
+              enableOnAndroid
+              refreshControl={
+                <RefreshControl
+                  refreshing={refreshing}
+                  onRefresh={onRefresh}
+                  tintColor={THEME.ink}
                 />
-              </ScrollView>
-            </SafeAreaView>
-          </Wallpaper>
-        </KeyboardAvoidingView>
+              }
+            >
+              <SubmissionsHero round={round} countdown={countdown} />
+              <SubmissionPhase
+                round={round}
+                userId={userId}
+                mySubmissions={mySubmissions}
+                onSubmitted={() => router.back()}
+              />
+            </KeyboardScroll>
+          </SafeAreaView>
+        </Wallpaper>
       </>
     );
   }


### PR DESCRIPTION
## What

On the submission screen, opening the keyboard left the focused text input flush against — or partially under — the keyboard. Switching between fields while the keyboard was already up could leave the new field covered entirely.

## Fix

Replaced the bespoke `KeyboardAvoidingView` + `ScrollView` (which relied on a magic `keyboardVerticalOffset` and, in iterations, `automaticallyAdjustKeyboardInsets` that gives no offset control) with the existing **`KeyboardScroll`** component (`src/components/KeyboardScroll.tsx`, wrapping `KeyboardAwareScrollView`).

It measures the focused input and scrolls it a controllable distance above the keyboard **on every focus**, and supports interactive swipe-to-dismiss. The gap is a single tunable knob:

- `extraScrollHeight={48}` — pixels kept between the keyboard top and the focused field.

Pure-JS change (no native rebuild needed).

## Testing

- `pnpm --filter @mix/mobile type-check` passes.
- Verified manually on device: every field scrolls clear of the keyboard (first tap and subsequent field switches), and swipe-down dismisses the keyboard.

## Note

`pnpm-lock.yaml` was intentionally left out of this PR — it currently has leftover git merge conflict markers (`<<<<<<< Updated upstream` / `>>>>>>> Stashed changes`) unrelated to this change and should be resolved separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)