### PR TITLE
Revamp Now Playing page + vote-as-you-listen

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -22,6 +22,7 @@ import {
 } from "@expo-google-fonts/jetbrains-mono";
 import { SessionProvider, useSession } from "@/context/SessionContext";
 import { LeagueProvider } from "@/context/LeagueContext";
+import { VotingDraftProvider } from "@/context/VotingDraftContext";
 import {
   SpotifyPlayerProvider,
   useSpotifyPlayer,
@@ -104,6 +105,7 @@ export default function RootLayout() {
           <SoundCloudPlayerProvider>
             <PlaybackProvider>
               <LeagueProvider>
+                <VotingDraftProvider>
                 <AuthGate>
                   <Stack
                     screenOptions={{ headerShown: false, animation: "fade" }}
@@ -116,6 +118,7 @@ export default function RootLayout() {
                     <Stack.Screen name="ui-preview" />
                   </Stack>
                 </AuthGate>
+                </VotingDraftProvider>
               </LeagueProvider>
             </PlaybackProvider>
           </SoundCloudPlayerProvider>

--- a/apps/mobile/src/components/NowPlayingModal.tsx
+++ b/apps/mobile/src/components/NowPlayingModal.tsx
@@ -1,24 +1,73 @@
-// Full-screen "Now Playing" modal — extracted from NowPlayingBar.tsx so the
+// Full-screen "Now Playing" page — extracted from NowPlayingBar.tsx so the
 // new floating pill (NowPlayingPillConnected) can render it without dragging
 // in the legacy mini-bar layout. Logic mirrors the original; if behavior in
 // the legacy NowPlayingBar evolves, port the change here too.
+//
+// Layout follows the Apple Music Now Playing reference: grab-handle bar up
+// top (swipe to dismiss), large centered album art, left-aligned title /
+// artist with a trailing "more" button, full-width scrubber (elapsed left,
+// remaining right), and large plain transport controls. Typography + color
+// stay on the bubblegum/iridescent theme used across the playlist + voting
+// screens — the reference is the source for *arrangement*, the theme for
+// *style*.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Alert,
   Animated,
   Dimensions,
   Image,
+  LayoutAnimation,
   PanResponder,
+  ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  FastForward,
+  MessageCircle,
+  MessageCircleMore,
+  Minus,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Plus,
+  Rewind,
+} from 'lucide-react-native';
 import { usePlayback } from '@/playback/PlaybackContext';
 import { SwipeSheet } from '@/components/SwipeSheet';
+import { Wallpaper } from '@/ui/Wallpaper';
+import { ChromeBorder } from '@/ui/ChromeBorder';
+import { ChromeButton } from '@/ui/ChromeButton';
+import { ChromeText } from '@/ui/ChromeText';
+import { PODIUM_STOPS } from '@/ui/metalStops';
+import { THEME } from '@/ui/theme';
+import { derivePhase } from '@/lib/utils/phase';
+import { useSession } from '@/context/SessionContext';
+import { useSubmissionRoundId } from '@/queries/useSubmissionRoundId';
+import { useRound } from '@/queries/useRound';
+import { useRoundResults } from '@/queries/useRoundResults';
+import { useRoundVoters } from '@/queries/useRoundVoters';
+import { useVotingDraft } from '@/queries/useVotingDraft';
+import { MixError } from '@/services/errors';
+import type { VoterEntry } from '@/services/results';
 
 const { width: SCREEN_W } = Dimensions.get('window');
+
+// Wash base lilac — used as the sheet's own background so the slide-up
+// animation never flashes black before the Wallpaper paints over it.
+const WASH_BASE = '#EDD7FF';
+
+// Album art sizing. The layout always reserves the LARGE footprint so the
+// title/artist line never shifts when the art resizes; the art itself scales
+// (with a bounce) between large while playing and small while paused.
+const ART_LARGE = SCREEN_W - 40; // playing — almost full-bleed (tighter gutters)
+const ART_SMALL = Math.round(SCREEN_W * 0.68); // paused — slightly larger than before
+const ART_SMALL_SCALE = ART_SMALL / ART_LARGE;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -50,6 +99,7 @@ function SeekBar({
   const displayMs = dragX !== null
     ? Math.round(displayProgress * durationMs)
     : positionMs;
+  const remainingMs = durationMs > 0 ? Math.max(0, durationMs - displayMs) : 0;
 
   const commitSeek = useCallback(
     (x: number) => {
@@ -84,67 +134,392 @@ function SeekBar({
         <View style={seekStyles.track}>
           <View style={[seekStyles.fill, { width: fillWidth }]} />
         </View>
-        <View style={[seekStyles.thumb, { left: Math.max(0, fillWidth - 6) }]} />
+        <View style={[seekStyles.thumb, { left: Math.max(0, fillWidth - 7) }]} />
       </View>
       <View style={seekStyles.labels}>
         <Text style={seekStyles.time}>{formatMs(displayMs)}</Text>
-        <Text style={seekStyles.time}>{durationMs > 0 ? formatMs(durationMs) : '--:--'}</Text>
+        <Text style={seekStyles.time}>
+          {durationMs > 0 ? `-${formatMs(remainingMs)}` : '--:--'}
+        </Text>
       </View>
     </View>
   );
 }
 
 const seekStyles = StyleSheet.create({
-  wrap: { width: '100%', gap: 6 },
+  wrap: { width: '100%', gap: 8 },
   hitArea: { height: 28, justifyContent: 'center', width: '100%' },
-  track: { height: 4, backgroundColor: '#333', borderRadius: 2, overflow: 'hidden' },
-  fill: { height: 4, backgroundColor: '#fff', borderRadius: 2 },
-  thumb: { position: 'absolute', width: 12, height: 12, borderRadius: 6, backgroundColor: '#fff', top: 8 },
+  track: {
+    height: 5,
+    backgroundColor: 'rgba(26,8,20,0.14)',
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+  fill: { height: 5, backgroundColor: THEME.ink, borderRadius: 3 },
+  thumb: {
+    position: 'absolute',
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    backgroundColor: THEME.ink,
+    top: 7,
+  },
   labels: { flexDirection: 'row', justifyContent: 'space-between' },
-  time: { fontSize: 11, color: '#666' },
+  time: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 10,
+    letterSpacing: 1.2,
+    color: THEME.muted,
+  },
 });
 
-// ─── ControlBtn ───────────────────────────────────────────────────────────────
+// ─── Transport controls ───────────────────────────────────────────────────────
 
-function ControlBtn({
-  label,
-  onPress,
-  disabled,
-  large,
+// Large, plain icon transport — no button backgrounds, matching the reference.
+// Big play/pause flanked by skip-back / skip-forward; ink glyphs on the wash.
+function Transport({
+  isPlaying,
+  onPlayPause,
+  onPrevious,
+  onNext,
+  hasTrack,
+  canPrevious,
+  hasNext,
 }: {
-  label: string;
-  onPress: () => void;
-  disabled?: boolean;
-  large?: boolean;
+  isPlaying: boolean;
+  onPlayPause: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  hasTrack: boolean;
+  canPrevious: boolean;
+  hasNext: boolean;
 }) {
   return (
-    <TouchableOpacity
-      onPress={onPress}
-      disabled={disabled}
-      style={[ctrlStyles.btn, large && ctrlStyles.btnLarge, disabled && ctrlStyles.btnDisabled]}
-    >
-      <Text style={[ctrlStyles.label, large && ctrlStyles.labelLarge]}>{label}</Text>
-    </TouchableOpacity>
+    <View style={ctrlStyles.row}>
+      <TouchableOpacity
+        onPress={onPrevious}
+        disabled={!canPrevious}
+        hitSlop={12}
+        style={[ctrlStyles.skip, !canPrevious && ctrlStyles.disabled]}
+      >
+        <Rewind size={34} color={THEME.ink} fill={THEME.ink} strokeWidth={0} />
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        onPress={onPlayPause}
+        disabled={!hasTrack}
+        hitSlop={12}
+        activeOpacity={0.7}
+        style={[ctrlStyles.play, !hasTrack && ctrlStyles.disabled]}
+      >
+        {isPlaying ? (
+          <Pause size={58} color={THEME.ink} fill={THEME.ink} strokeWidth={0} />
+        ) : (
+          <Play
+            size={58}
+            color={THEME.ink}
+            fill={THEME.ink}
+            strokeWidth={0}
+            style={{ marginLeft: 4 }}
+          />
+        )}
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        onPress={onNext}
+        disabled={!hasNext}
+        hitSlop={12}
+        style={[ctrlStyles.skip, !hasNext && ctrlStyles.disabled]}
+      >
+        <FastForward size={34} color={THEME.ink} fill={THEME.ink} strokeWidth={0} />
+      </TouchableOpacity>
+    </View>
   );
 }
 
 const ctrlStyles = StyleSheet.create({
-  btn: { width: 52, height: 52, borderRadius: 26, backgroundColor: '#222', alignItems: 'center', justifyContent: 'center' },
-  btnLarge: { width: 68, height: 68, borderRadius: 34, backgroundColor: '#fff' },
-  btnDisabled: { opacity: 0.3 },
-  label: { fontSize: 20, color: '#fff' },
-  labelLarge: { fontSize: 26, color: '#000' },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 40,
+    marginTop: 4,
+  },
+  skip: { width: 44, height: 44, alignItems: 'center', justifyContent: 'center' },
+  play: { width: 72, height: 72, alignItems: 'center', justifyContent: 'center' },
+  disabled: { opacity: 0.3 },
 });
 
-// ─── Album art swiper (inside modal) ─────────────────────────────────────────
+// ─── Round panel (completed round) ──────────────────────────────────────────────
 
-const ART_SIZE = 240;
+// Stable pastel for a voter avatar — same approach as PlaylistScreen so the
+// read-only comments accordion reads identically across surfaces.
+const AVATAR_PASTELS = [
+  '#F5C8E2',
+  '#E2C8F5',
+  '#FFE3B8',
+  '#C8E5C8',
+  '#FFC8C8',
+  '#C8DAEF',
+  '#FFD7E8',
+];
+function pastelFor(id: string): string {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return AVATAR_PASTELS[h % AVATAR_PASTELS.length];
+}
 
-type SwiperPanel = { artworkUrl: string; title: string; artist: string } | null;
+// Completed-round panel: the track's playlist rank + total score, with a
+// comment opener that expands the read-only voter comments (same data + shape
+// as the PlaylistScreen accordion). The active-voting variant (inline
+// steppers + comment composer) is intentionally not here yet — it needs a
+// shared ballot draft to satisfy the all-or-nothing submit_votes contract.
+function CompletedRoundPanel({
+  rank,
+  points,
+  isVoid,
+  comments,
+}: {
+  rank: number | null;
+  points: number;
+  isVoid: boolean;
+  comments: VoterEntry[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasComments = comments.length > 0;
+
+  const toggle = () => {
+    if (!hasComments) return;
+    LayoutAnimation.configureNext({
+      duration: 180,
+      create: { type: 'easeInEaseOut', property: 'opacity' },
+      update: { type: 'easeInEaseOut' },
+      delete: { type: 'easeInEaseOut', property: 'opacity' },
+    });
+    setExpanded((v) => !v);
+  };
+
+  return (
+    <View style={roundStyles.wrap}>
+      {/* Three equal columns so the score pill stays dead-center regardless of
+          how wide the rank / comment content is (#3 vs #10, 1 vs 12 comments). */}
+      <View style={roundStyles.statsRow}>
+        <View style={roundStyles.statsSide}>
+          {rank !== null ? (
+            <View style={roundStyles.rankPill}>
+              {rank <= 3 ? (
+                <ChromeText
+                  glyph="★"
+                  size={13}
+                  colors={PODIUM_STOPS[rank as 1 | 2 | 3]}
+                />
+              ) : null}
+              <Text style={roundStyles.rankText}>#{rank}</Text>
+            </View>
+          ) : isVoid ? (
+            <View style={roundStyles.rankPill}>
+              <Text style={roundStyles.rankText}>Forfeited</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={roundStyles.statsCenter}>
+          <View style={roundStyles.scorePill}>
+            <Text style={roundStyles.scoreText}>{points}</Text>
+            <Text style={roundStyles.scoreUnit}>
+              {points === 1 ? 'pt' : 'pts'}
+            </Text>
+          </View>
+        </View>
+
+        <View style={roundStyles.statsSideRight}>
+          <TouchableOpacity
+            style={[roundStyles.commentBtn, !hasComments && { opacity: 0.3 }]}
+            onPress={toggle}
+            hitSlop={8}
+            disabled={!hasComments}
+          >
+            {hasComments ? (
+              <MessageCircleMore
+                size={22}
+                color={THEME.ink}
+                fill={THEME.ink}
+                strokeWidth={2}
+                opacity={expanded ? 1 : 0.75}
+              />
+            ) : (
+              <MessageCircle size={22} color={THEME.ink} strokeWidth={2} />
+            )}
+            {hasComments ? (
+              <Text style={roundStyles.commentCount}>{comments.length}</Text>
+            ) : null}
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {expanded && hasComments ? (
+        <ScrollView
+          style={roundStyles.accordion}
+          contentContainerStyle={{ padding: 12, gap: 8 }}
+          showsVerticalScrollIndicator={false}
+        >
+          {comments.map((v, i) => (
+            <View key={v.voter_user_id}>
+              {i > 0 ? <View style={roundStyles.accordionDivider} /> : null}
+              <View style={roundStyles.commentRow}>
+                <ChromeBorder
+                  radius={13}
+                  thickness={1.5}
+                  innerBg={pastelFor(v.voter_user_id)}
+                  clip
+                  style={roundStyles.commentAvatar}
+                >
+                  <View style={roundStyles.commentAvatarCenter}>
+                    <Text style={roundStyles.commentAvatarInitial}>
+                      {(v.voter_name ?? '?').charAt(0).toUpperCase()}
+                    </Text>
+                  </View>
+                </ChromeBorder>
+                <View style={roundStyles.commentTextCol}>
+                  <Text style={roundStyles.commentVoterName} numberOfLines={1}>
+                    {v.voter_name}
+                  </Text>
+                  <Text style={roundStyles.commentText}>
+                    &ldquo;{v.comment}&rdquo;
+                  </Text>
+                </View>
+              </View>
+            </View>
+          ))}
+        </ScrollView>
+      ) : null}
+    </View>
+  );
+}
+
+const roundStyles = StyleSheet.create({
+  wrap: { width: '100%', gap: 10 },
+  statsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  // Equal side/center columns keep the score pill centered on screen no matter
+  // how wide the rank or comment content is.
+  statsSide: { flex: 1, alignItems: 'flex-start' },
+  statsCenter: { flexShrink: 0, alignItems: 'center', paddingHorizontal: 8 },
+  statsSideRight: { flex: 1, alignItems: 'flex-end' },
+  rankPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 999,
+    backgroundColor: '#2a0e4a',
+  },
+  rankText: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 12,
+    color: '#e8d5ff',
+  },
+  scorePill: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 3,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    borderRadius: 999,
+    backgroundColor: 'rgba(26,8,20,0.06)',
+  },
+  scoreText: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 13,
+    color: THEME.ink,
+  },
+  scoreUnit: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 11,
+    color: THEME.muted,
+  },
+  commentBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  commentCount: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 12,
+    color: THEME.ink,
+  },
+  accordion: {
+    width: '100%',
+    maxHeight: 168,
+    backgroundColor: 'rgba(255,255,255,0.45)',
+    borderRadius: 12,
+  },
+  accordionDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: 'rgba(26,8,20,0.12)',
+    marginLeft: 36,
+  },
+  commentRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  commentAvatar: { width: 26, height: 26 },
+  commentAvatarCenter: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  commentAvatarInitial: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 11,
+    color: THEME.ink,
+  },
+  commentTextCol: { flex: 1, gap: 1 },
+  commentVoterName: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 12,
+    color: THEME.ink,
+  },
+  commentText: {
+    fontFamily: THEME.fonts.serifItalic,
+    fontSize: 13,
+    lineHeight: 17,
+    color: THEME.muted,
+  },
+});
+
+// ─── Album art swiper ──────────────────────────────────────────────────────────
 
 function AlbumArtSwiper() {
-  const { currentIndex, playlist, artworkUrl, title, artist, next, previous } = usePlayback();
+  const { currentIndex, playlist, artworkUrl, isPlaying, next, previous } = usePlayback();
   const translateX = useRef(new Animated.Value(0)).current;
+
+  // A single `progress` value (0 = paused/small, 1 = playing/large) drives both
+  // the scale and the shadow so they stay in step: the art "lifts" off the
+  // surface — shadow fading in as it grows, gone when it sits small and flat.
+  // Kept on the NATIVE driver (transform + opacity only) for smoothness — the
+  // shadow fade is done by cross-fading a separate shadow plate's opacity
+  // rather than animating shadowOpacity (which would force the JS driver and
+  // stutter). Scale overshoots past 1 on grow for a slight spring; no
+  // undershoot on shrink. The swiper window is `overflow: visible` so the grow
+  // overshoot is never clipped.
+  const progress = useRef(new Animated.Value(isPlaying ? 1 : 0)).current;
+  useEffect(() => {
+    Animated.spring(progress, {
+      toValue: isPlaying ? 1 : 0,
+      speed: isPlaying ? 4 : 6,
+      bounciness: isPlaying ? 13 : 0,
+      useNativeDriver: true,
+    }).start();
+  }, [isPlaying, progress]);
+
+  const scale = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [ART_SMALL_SCALE, 1],
+  });
+  const shadowFade = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 1],
+    extrapolate: 'clamp',
+  });
 
   const artCache = useRef(new Map<string, string>());
 
@@ -182,17 +557,9 @@ function AlbumArtSwiper() {
   nextFnRef.current = next;
   prevFnRef.current = previous;
 
-  const prevPanel: SwiperPanel = hasPrevRef.current && currentIndex !== null
-    ? { artworkUrl: getArtUrl(currentIndex - 1), title: playlist[currentIndex - 1].title, artist: playlist[currentIndex - 1].artist }
-    : null;
-  const currentPanel: SwiperPanel = {
-    artworkUrl: (currentIndex !== null ? getArtUrl(currentIndex) : '') || artworkUrl || '',
-    title,
-    artist,
-  };
-  const nextPanel: SwiperPanel = hasNextRef.current && currentIndex !== null
-    ? { artworkUrl: getArtUrl(currentIndex + 1), title: playlist[currentIndex + 1].title, artist: playlist[currentIndex + 1].artist }
-    : null;
+  const prevArt = hasPrevRef.current && currentIndex !== null ? getArtUrl(currentIndex - 1) : '';
+  const currentArt = (currentIndex !== null ? getArtUrl(currentIndex) : '') || artworkUrl || '';
+  const nextArt = hasNextRef.current && currentIndex !== null ? getArtUrl(currentIndex + 1) : '';
 
   const panResponder = useRef(
     PanResponder.create({
@@ -231,17 +598,25 @@ function AlbumArtSwiper() {
     }),
   ).current;
 
-  const renderPanel = (panel: SwiperPanel, key: string) => (
+  const renderArt = (url: string, key: string) => (
     <View key={key} style={artSwiperStyles.panel}>
-      {panel?.artworkUrl ? (
-        <Image source={{ uri: panel.artworkUrl }} style={artSwiperStyles.art} />
-      ) : (
-        <View style={[artSwiperStyles.art, artSwiperStyles.placeholder]}>
-          <Text style={artSwiperStyles.placeholderText}>♪</Text>
+      <Animated.View style={[artSwiperStyles.artScaleWrap, { transform: [{ scale }] }]}>
+        {/* Separate shadow plate behind the art — its opacity cross-fades on
+            the native driver (smooth) so the shadow only shows once lifted. */}
+        <Animated.View
+          style={[artSwiperStyles.artShadowPlate, { opacity: shadowFade }]}
+          pointerEvents="none"
+        />
+        <View style={artSwiperStyles.artFrame}>
+          {url ? (
+            <Image source={{ uri: url }} style={artSwiperStyles.art} />
+          ) : (
+            <View style={[artSwiperStyles.art, artSwiperStyles.placeholder]}>
+              <ChromeText glyph="♪" size={72} />
+            </View>
+          )}
         </View>
-      )}
-      <Text style={artSwiperStyles.title} numberOfLines={1}>{panel?.title ?? ''}</Text>
-      <Text style={artSwiperStyles.artist} numberOfLines={1}>{panel?.artist ?? ''}</Text>
+      </Animated.View>
     </View>
   );
 
@@ -253,35 +628,332 @@ function AlbumArtSwiper() {
           { transform: [{ translateX: Animated.add(translateX, new Animated.Value(-SCREEN_W)) }] },
         ]}
       >
-        {renderPanel(prevPanel, 'prev')}
-        {renderPanel(currentPanel, 'current')}
-        {renderPanel(nextPanel, 'next')}
+        {renderArt(prevArt, 'prev')}
+        {renderArt(currentArt, 'current')}
+        {renderArt(nextArt, 'next')}
       </Animated.View>
     </View>
   );
 }
 
 const artSwiperStyles = StyleSheet.create({
-  window: {
-    width: SCREEN_W,
+  // `visible` (not hidden) so the grow spring's slight overshoot isn't clipped.
+  // The off-screen prev/next panels sit exactly one screen-width away, so the
+  // device edge clips them — no neighbour peeking at rest.
+  window: { width: SCREEN_W, overflow: 'visible' },
+  row: { flexDirection: 'row', width: SCREEN_W * 3 },
+  panel: { width: SCREEN_W, alignItems: 'center', justifyContent: 'center' },
+  artScaleWrap: {
+    width: ART_LARGE,
+    height: ART_LARGE,
+  },
+  // Soft, modern drop shadow — on-theme plum rather than hard black, with a
+  // wide blur and gentle offset so it reads as a smooth lift off the wash. Its
+  // own opacity is cross-faded (native driver) so the shadow only shows once
+  // the art has lifted to the large size. The wash-colored backing lets the
+  // rounded shadow render cleanly; it's fully covered by the art on top.
+  artShadowPlate: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 12,
+    backgroundColor: WASH_BASE,
+    shadowColor: '#1A0814',
+    shadowOpacity: 0.3,
+    shadowRadius: 26,
+    shadowOffset: { width: 0, height: 16 },
+    elevation: 12,
+  },
+  artFrame: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 12,
     overflow: 'hidden',
-    marginVertical: 8,
   },
-  row: {
-    flexDirection: 'row',
-    width: SCREEN_W * 3,
-  },
-  panel: {
-    width: SCREEN_W,
+  art: { width: '100%', height: '100%' },
+  placeholder: {
+    backgroundColor: 'rgba(26,8,20,0.06)',
     alignItems: 'center',
-    gap: 6,
-    paddingBottom: 4,
+    justifyContent: 'center',
   },
-  art: { width: ART_SIZE, height: ART_SIZE, borderRadius: 12 },
-  placeholder: { backgroundColor: '#111', alignItems: 'center', justifyContent: 'center', borderRadius: 12 },
-  placeholderText: { fontSize: 64, color: '#333' },
-  title: { fontSize: 22, fontWeight: '700', color: '#fff', textAlign: 'center', paddingHorizontal: 32 },
-  artist: { fontSize: 15, color: '#888', textAlign: 'center', paddingHorizontal: 32 },
+});
+
+// ─── Voting panel (active round) ────────────────────────────────────────────────
+
+type VotingDraftApi = ReturnType<typeof useVotingDraft>;
+
+// Vote-as-you-listen: steppers for the *current* track that build a shared,
+// server-persisted ballot draft (the same draft the voting screen edits). The
+// whole budget is spent across the playlist as you go; "Submit ballot" lights
+// up only when every point is allocated. Read-only once the ballot is in.
+function VotingPanel({ draft, subId }: { draft: VotingDraftApi; subId: string }) {
+  const [composerOpen, setComposerOpen] = useState(false);
+  const pts = draft.points(subId);
+  const own = draft.isOwn(subId);
+  const commentText = draft.comment(subId);
+
+  const onSubmit = useCallback(async () => {
+    try {
+      await draft.submitBallot();
+    } catch (e) {
+      Alert.alert('Submit failed', e instanceof MixError ? e.message : 'Unknown error');
+    }
+  }, [draft]);
+
+  // Locked, read-only view once the user has voted.
+  if (draft.alreadyVoted) {
+    return (
+      <View style={voteStyles.card}>
+        <View style={voteStyles.headerRow}>
+          <Text style={voteStyles.label}>Your vote</Text>
+          <Text style={voteStyles.savedHint}>Locked in ✓</Text>
+        </View>
+        <View style={voteStyles.votedRow}>
+          <Text style={voteStyles.votedText}>
+            {own
+              ? 'Your track'
+              : pts > 0
+                ? 'You gave this track'
+                : 'No points on this track'}
+          </Text>
+          {!own && pts > 0 ? (
+            <View style={voteStyles.ptsPill}>
+              <Text style={voteStyles.ptsPillText}>+{pts}</Text>
+            </View>
+          ) : null}
+        </View>
+        {!own && commentText.trim().length > 0 ? (
+          <Text style={voteStyles.votedComment}>
+            &ldquo;{commentText.trim()}&rdquo;
+          </Text>
+        ) : null}
+      </View>
+    );
+  }
+
+  // Not editable yet (draft still hydrating, or not eligible) → render nothing.
+  if (!draft.canEdit) return null;
+
+  const plusDisabled = draft.remaining === 0 || pts >= draft.maxPerTrack;
+
+  return (
+    <View style={voteStyles.card}>
+      <View style={voteStyles.headerRow}>
+        <Text style={voteStyles.label}>Your vote</Text>
+        <Text style={voteStyles.savedHint}>
+          {draft.saving ? 'Saving…' : draft.dirty ? 'Saving…' : 'Saved'}
+        </Text>
+      </View>
+
+      {own ? (
+        <Text style={voteStyles.ownNote}>You can&apos;t vote for your own track.</Text>
+      ) : (
+        <>
+          <View style={voteStyles.stepperRow}>
+            <TouchableOpacity
+              style={[voteStyles.stepBtn, pts === 0 && voteStyles.stepDisabled]}
+              onPress={() => draft.adjust(subId, -1)}
+              disabled={pts === 0}
+              hitSlop={8}
+            >
+              <Minus size={22} color={THEME.ink} strokeWidth={3} />
+            </TouchableOpacity>
+            <View style={voteStyles.ptsBox}>
+              <Text style={voteStyles.ptsNum}>{pts}</Text>
+              <Text style={voteStyles.ptsUnit}>{pts === 1 ? 'pt' : 'pts'}</Text>
+            </View>
+            <TouchableOpacity
+              style={[voteStyles.stepBtn, plusDisabled && voteStyles.stepDisabled]}
+              onPress={() => draft.adjust(subId, 1)}
+              disabled={plusDisabled}
+              hitSlop={8}
+            >
+              <Plus size={22} color={THEME.ink} strokeWidth={3} />
+            </TouchableOpacity>
+          </View>
+
+          <TouchableOpacity
+            style={voteStyles.commentToggle}
+            onPress={() => setComposerOpen((v) => !v)}
+            hitSlop={6}
+          >
+            {commentText.trim().length > 0 ? (
+              <MessageCircleMore
+                size={18}
+                color={THEME.ink}
+                fill={THEME.ink}
+                strokeWidth={2}
+              />
+            ) : (
+              <MessageCircle size={18} color={THEME.ink} strokeWidth={2} />
+            )}
+            <Text style={voteStyles.commentToggleText}>
+              {commentText.trim().length > 0 ? 'Edit comment' : 'Add a comment'}
+            </Text>
+          </TouchableOpacity>
+
+          {composerOpen ? (
+            <TextInput
+              style={voteStyles.composer}
+              value={commentText}
+              onChangeText={(v) => draft.setComment(subId, v)}
+              placeholder="Leave a comment for this track…"
+              placeholderTextColor={THEME.faint}
+              multiline
+              textAlignVertical="top"
+            />
+          ) : null}
+        </>
+      )}
+
+      <Text style={voteStyles.budget}>
+        {draft.remaining} of {draft.total} pts left · max {draft.maxPerTrack}/track
+      </Text>
+
+      <ChromeButton
+        onPress={onSubmit}
+        disabled={!draft.canSubmit}
+        radius={22}
+        paddingVertical={12}
+      >
+        <Text style={voteStyles.submitText}>
+          {draft.submitting
+            ? 'Submitting…'
+            : draft.remaining === 0
+              ? 'Submit ballot'
+              : `Spend ${draft.remaining} more to submit`}
+        </Text>
+      </ChromeButton>
+    </View>
+  );
+}
+
+const voteStyles = StyleSheet.create({
+  card: {
+    width: '100%',
+    backgroundColor: 'rgba(255,255,255,0.5)',
+    borderRadius: 16,
+    padding: 14,
+    gap: 12,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: 'uppercase',
+    color: THEME.ink,
+  },
+  savedHint: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 9.5,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    color: THEME.faint,
+  },
+  stepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24,
+  },
+  stepBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(26,8,20,0.07)',
+  },
+  stepDisabled: { opacity: 0.3 },
+  ptsBox: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 4,
+    minWidth: 64,
+    justifyContent: 'center',
+  },
+  ptsNum: {
+    fontFamily: THEME.fonts.serifBoldItalic,
+    fontSize: 30,
+    color: THEME.ink,
+  },
+  ptsUnit: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 12,
+    color: THEME.muted,
+  },
+  ownNote: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 13,
+    color: THEME.muted,
+    textAlign: 'center',
+  },
+  commentToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  commentToggleText: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 13,
+    color: THEME.ink,
+  },
+  composer: {
+    minHeight: 56,
+    maxHeight: 96,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.65)',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 14,
+    color: THEME.ink,
+  },
+  budget: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 10,
+    letterSpacing: 0.8,
+    color: THEME.muted,
+    textAlign: 'center',
+  },
+  submitText: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 14,
+    color: THEME.ink,
+  },
+  votedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  votedText: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 14,
+    color: THEME.ink,
+  },
+  ptsPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 999,
+    backgroundColor: '#2a0e4a',
+  },
+  ptsPillText: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 12,
+    color: '#e8d5ff',
+  },
+  votedComment: {
+    fontFamily: THEME.fonts.serifItalic,
+    fontSize: 13,
+    lineHeight: 17,
+    color: THEME.muted,
+    textAlign: 'center',
+  },
 });
 
 // ─── Modal ────────────────────────────────────────────────────────────────────
@@ -290,7 +962,7 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
   const insets = useSafeAreaInsets();
   const {
     currentIndex, playlist,
-    isPlaying, positionMs, durationMs,
+    isPlaying, positionMs, durationMs, title, artist,
     pause, resume, seek, next, previous,
   } = usePlayback();
 
@@ -301,6 +973,50 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
   const canPrevious = currentIndex !== null;
   const hasNext = currentIndex !== null && currentIndex < playlist.length - 1;
 
+  // ── Round context for the current track ──
+  // A PlaylistTrack.id is a submission id; resolve it to its round, derive the
+  // phase, and (when complete) surface the track's rank / score / comments.
+  const currentSubId = currentIndex !== null ? playlist[currentIndex]?.id : undefined;
+  const { supabaseUserId } = useSession();
+  const { data: roundId } = useSubmissionRoundId(currentSubId);
+  const { data: round } = useRound(roundId ?? undefined);
+  const phase = round ? derivePhase(round) : null;
+
+  // Active-round voting facade (steppers + comment + submit) for the current
+  // track. Shares the persisted draft with the voting screen.
+  const draft = useVotingDraft(roundId ?? undefined, supabaseUserId ?? undefined);
+  const showVoting = phase === 'voting' && draft.didSubmit && !!currentSubId;
+  // Only pull results/voters once the round is complete — during voting these
+  // would be a spoiler (and a wasted fetch).
+  const resultsRoundId = phase === 'results' ? roundId ?? undefined : undefined;
+  const { data: results = [] } = useRoundResults(resultsRoundId);
+  const { data: voters = {} } = useRoundVoters(resultsRoundId);
+
+  const completed = useMemo(() => {
+    if (phase !== 'results' || !currentSubId) return null;
+    const me = results.find((r) => r.submission_id === currentSubId);
+    // Rank = position among non-forfeited tracks, by effective points (raw as
+    // tiebreaker, id for stability) — mirrors the results/playlist screens.
+    const eligible = results
+      .filter((r) => !r.is_void)
+      .sort(
+        (a, b) =>
+          b.points_effective - a.points_effective ||
+          b.points_raw - a.points_raw ||
+          a.submission_id.localeCompare(b.submission_id),
+      );
+    const idx = eligible.findIndex((r) => r.submission_id === currentSubId);
+    const trackComments = (voters[currentSubId] ?? []).filter(
+      (v) => (v.comment ?? '').trim().length > 0,
+    );
+    return {
+      rank: idx >= 0 ? idx + 1 : null,
+      points: me?.points_effective ?? 0,
+      isVoid: me?.is_void ?? false,
+      comments: trackComments,
+    };
+  }, [phase, currentSubId, results, voters]);
+
   return (
     <SwipeSheet
       visible={visible}
@@ -308,79 +1024,146 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
       closeDuration={300}
       dismissThreshold={80}
       dismissVelocityThreshold={0.5}
-      backgroundColor="#000"
-      backdropColor="rgba(0,0,0,0.45)"
-      renderHeaderRight={({ dismiss }) => (
-        <TouchableOpacity onPress={dismiss} style={modalStyles.collapseBtn} hitSlop={{ top: 12, bottom: 12, left: 24, right: 24 }}>
-          <Text style={modalStyles.collapseIcon}>⌄</Text>
-        </TouchableOpacity>
-      )}
+      backgroundColor={WASH_BASE}
+      backdropColor="rgba(26,8,20,0.4)"
+      // Hide the built-in handle strip so the iridescent wash can cover the
+      // full sheet edge-to-edge (the strip would otherwise sit on the flat
+      // sheet background, leaving a seam where the wash blooms begin). We
+      // render our own grab handle inside the Wallpaper below.
+      showHandle={false}
     >
       {() => (
-        <>
-          <View style={[modalStyles.content, { paddingBottom: insets.bottom + 24 }]}>
-            <Text style={modalStyles.heading}>Now Playing</Text>
+        <Wallpaper halftone={false}>
+          {/* Grab handle — signals swipe-to-dismiss. */}
+          <View style={[modalStyles.topBar, { paddingTop: insets.top + 10 }]}>
+            <View style={modalStyles.handle} />
+          </View>
 
-            <AlbumArtSwiper />
-
-            <SeekBar positionMs={positionMs} durationMs={durationMs} onSeek={seek} />
-
-            <View style={modalStyles.controls}>
-              <ControlBtn label="⏮" onPress={previous} disabled={!canPrevious} />
-              <ControlBtn
-                label={isPlaying ? '⏸' : '▶'}
-                onPress={isPlaying ? pause : resume}
-                disabled={!hasTrack}
-                large
-              />
-              <ControlBtn label="⏭" onPress={next} disabled={!hasNext} />
+          <View style={[modalStyles.content, { paddingBottom: insets.bottom + 18 }]}>
+            <View style={modalStyles.artBlock}>
+              <AlbumArtSwiper />
             </View>
 
-            {hasTrack && (
-              <View style={modalStyles.votingPlaceholder}>
-                <Text style={modalStyles.votingLabel}>VOTING</Text>
-                <Text style={modalStyles.votingBody}>
-                  Point allocation controls will appear here when this track is part of an active voting round.
-                </Text>
+            {/* Everything under the art. The title is pinned just below the
+                (large) art footprint so it never shifts when the art scales;
+                the controls + scrubber float vertically centered in the space
+                between the title and the bottom panel. */}
+            <View style={modalStyles.belowArt}>
+              <View style={modalStyles.titleRow}>
+                <View style={modalStyles.titleCol}>
+                  <Text style={modalStyles.title} numberOfLines={1}>
+                    {title || (hasTrack ? 'Loading…' : 'Nothing playing')}
+                  </Text>
+                  {artist ? (
+                    <Text style={modalStyles.artist} numberOfLines={1}>
+                      {artist}
+                    </Text>
+                  ) : null}
+                </View>
+                <TouchableOpacity
+                  style={modalStyles.moreBtn}
+                  hitSlop={8}
+                  // TODO: overflow menu (add to playlist, share, view round…).
+                  onPress={() => {}}
+                >
+                  <MoreHorizontal size={20} color={THEME.ink} strokeWidth={2.5} />
+                </TouchableOpacity>
               </View>
-            )}
+
+              <View style={modalStyles.controlsRegion}>
+                {/* Transport sits above the scrubber per the requested layout. */}
+                <Transport
+                  isPlaying={isPlaying}
+                  onPlayPause={isPlaying ? pause : resume}
+                  onPrevious={previous}
+                  onNext={next}
+                  hasTrack={hasTrack}
+                  canPrevious={canPrevious}
+                  hasNext={hasNext}
+                />
+
+                <SeekBar positionMs={positionMs} durationMs={durationMs} onSeek={seek} />
+              </View>
+
+              {completed ? (
+                <CompletedRoundPanel
+                  rank={completed.rank}
+                  points={completed.points}
+                  isVoid={completed.isVoid}
+                  comments={completed.comments}
+                />
+              ) : null}
+
+              {showVoting ? (
+                <VotingPanel draft={draft} subId={currentSubId!} />
+              ) : null}
+            </View>
           </View>
-        </>
+        </Wallpaper>
       )}
     </SwipeSheet>
   );
 }
 
 const modalStyles = StyleSheet.create({
-  collapseBtn: { paddingVertical: 4, paddingHorizontal: 4 },
-  collapseIcon: {
-    fontSize: 28,
-    color: '#888',
-    lineHeight: 32,
+  topBar: {
+    alignItems: 'center',
+    paddingBottom: 6,
+  },
+  handle: {
+    width: 36,
+    height: 5,
+    borderRadius: 3,
+    backgroundColor: 'rgba(26,8,20,0.22)',
   },
   content: {
     flex: 1,
-    paddingHorizontal: 32,
     alignItems: 'center',
-    gap: 20,
+    paddingTop: 8,
   },
-  heading: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#666',
-    letterSpacing: 1.5,
-    textTransform: 'uppercase',
+  artBlock: {
+    alignItems: 'center',
+    marginTop: 8,
   },
-  controls: { flexDirection: 'row', alignItems: 'center', gap: 24, marginTop: 8 },
-  votingPlaceholder: {
+  // Fills the space under the art. Title pinned at the top, controls centered
+  // in the middle (controlsRegion flex:1), any round panel at the bottom.
+  belowArt: {
+    flex: 1,
     width: '100%',
-    backgroundColor: '#111',
-    borderRadius: 12,
-    padding: 16,
-    gap: 6,
-    borderWidth: 1,
-    borderColor: '#222',
+    paddingHorizontal: 30,
   },
-  votingLabel: { fontSize: 10, fontWeight: '800', color: '#1DB954', letterSpacing: 1.5 },
-  votingBody: { fontSize: 13, color: '#555', lineHeight: 18 },
+  controlsRegion: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 18,
+    width: '100%',
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 36,
+  },
+  titleCol: { flex: 1, minWidth: 0, gap: 3 },
+  title: {
+    fontFamily: THEME.fonts.serifBoldItalic,
+    fontSize: 26,
+    lineHeight: 30,
+    letterSpacing: -0.6,
+    color: THEME.ink,
+  },
+  artist: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 15,
+    color: THEME.muted,
+  },
+  moreBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(26,8,20,0.06)',
+  },
 });

--- a/apps/mobile/src/context/VotingDraftContext.tsx
+++ b/apps/mobile/src/context/VotingDraftContext.tsx
@@ -1,0 +1,304 @@
+// Local-authoritative draft ballot store with backend sync.
+//
+// The desync trap: if the editable ballot lives in the TanStack Query cache,
+// any refetch (window focus, the round-prefix invalidation after submit, etc.)
+// can overwrite the user's in-flight edits with a *stale* server draft — the
+// ballot visibly "falls behind." So drafts are NOT a query. Instead:
+//
+//   1. Hydrate from the server ONCE per (round, user) on first use.
+//   2. Local state is the single source of truth for every read + write
+//      thereafter — edits are instant/optimistic and never clobbered.
+//   3. We only ever PUSH to the server (debounced ~1.5s, plus a flush when the
+//      app backgrounds so a kill doesn't lose the last edit).
+//
+// Both the voting screen and the Now Playing modal read the SAME provider
+// entry, so they stay in lockstep within a session, and progress survives an
+// app kill because it's persisted server-side (see migration
+// 20260530000000_vote_drafts.sql).
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { AppState } from "react-native";
+import {
+  getVoteDraft,
+  saveVoteDraft,
+  type VoteDraft,
+} from "@/services/voteDrafts";
+
+type Updater<T> = (prev: T) => T;
+
+type DraftEntry = VoteDraft & {
+  // Server draft loaded (or confirmed absent) at least once. Until true, the
+  // UI should treat the ballot as still loading rather than empty.
+  hydrated: boolean;
+  // A push is in flight (surfaced as a subtle "Saving…/Saved" hint).
+  saving: boolean;
+  // Local has edits not yet confirmed persisted.
+  dirty: boolean;
+};
+
+const FRESH: DraftEntry = {
+  allocation: {},
+  comments: {},
+  hydrated: false,
+  saving: false,
+  dirty: false,
+};
+
+interface VotingDraftContextValue {
+  entries: Record<string, DraftEntry>;
+  ensureHydrated: (roundId: string, userId: string) => void;
+  setAllocation: (
+    roundId: string,
+    userId: string,
+    updater: Updater<Record<string, number>>,
+  ) => void;
+  setComments: (
+    roundId: string,
+    userId: string,
+    updater: Updater<Record<string, string>>,
+  ) => void;
+  cancelSave: (roundId: string, userId: string) => void;
+}
+
+const Ctx = createContext<VotingDraftContextValue | null>(null);
+
+const SAVE_DELAY_MS = 1500;
+const keyOf = (roundId: string, userId: string) => `${roundId}::${userId}`;
+
+export function VotingDraftProvider({ children }: { children: ReactNode }) {
+  const [entries, setEntries] = useState<Record<string, DraftEntry>>({});
+
+  // Mirror of `entries` for reading the latest snapshot inside async callbacks
+  // (debounced saves) without stale closures.
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // Monotonic edit counter per key — lets a completed save know whether newer
+  // edits arrived while it was in flight (so it doesn't wrongly mark clean).
+  const versions = useRef<Map<string, number>>(new Map());
+  const hydrating = useRef<Set<string>>(new Set());
+
+  const doSave = useCallback((roundId: string, userId: string) => {
+    const key = keyOf(roundId, userId);
+    const entry = entriesRef.current[key];
+    if (!entry) return;
+    const versionAtSave = versions.current.get(key) ?? 0;
+    setEntries((prev) =>
+      prev[key] ? { ...prev, [key]: { ...prev[key], saving: true } } : prev,
+    );
+    saveVoteDraft(roundId, userId, {
+      allocation: entry.allocation,
+      comments: entry.comments,
+    })
+      .then(() => {
+        setEntries((prev) => {
+          const cur = prev[key];
+          if (!cur) return prev;
+          // Only mark clean if nothing changed since this save started.
+          const stillCurrent =
+            (versions.current.get(key) ?? 0) === versionAtSave;
+          return {
+            ...prev,
+            [key]: { ...cur, saving: false, dirty: stillCurrent ? false : cur.dirty },
+          };
+        });
+      })
+      .catch(() => {
+        // Keep dirty=true so the next edit (or background flush) retries.
+        setEntries((prev) =>
+          prev[key] ? { ...prev, [key]: { ...prev[key], saving: false } } : prev,
+        );
+      });
+  }, []);
+
+  const scheduleSave = useCallback(
+    (roundId: string, userId: string) => {
+      const key = keyOf(roundId, userId);
+      const existing = timers.current.get(key);
+      if (existing) clearTimeout(existing);
+      timers.current.set(
+        key,
+        setTimeout(() => {
+          timers.current.delete(key);
+          doSave(roundId, userId);
+        }, SAVE_DELAY_MS),
+      );
+    },
+    [doSave],
+  );
+
+  const flushAll = useCallback(() => {
+    for (const [key, t] of timers.current.entries()) {
+      clearTimeout(t);
+      timers.current.delete(key);
+      const sep = key.indexOf("::");
+      doSave(key.slice(0, sep), key.slice(sep + 2));
+    }
+  }, [doSave]);
+
+  // Persist pending edits when the app backgrounds — covers "kill the app"
+  // better than the debounce window alone.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (s) => {
+      if (s === "background" || s === "inactive") flushAll();
+    });
+    return () => sub.remove();
+  }, [flushAll]);
+
+  const ensureHydrated = useCallback((roundId: string, userId: string) => {
+    const key = keyOf(roundId, userId);
+    if (hydrating.current.has(key)) return;
+    if (entriesRef.current[key]?.hydrated) return;
+    hydrating.current.add(key);
+    getVoteDraft(roundId, userId)
+      .then((server) => {
+        setEntries((prev) => {
+          const cur = prev[key];
+          if (cur?.hydrated) return prev;
+          // If the user already edited before the server responded, their
+          // local edits are the newer truth — keep them, just mark hydrated.
+          if (cur?.dirty) return { ...prev, [key]: { ...cur, hydrated: true } };
+          return {
+            ...prev,
+            [key]: {
+              allocation: server.allocation,
+              comments: server.comments,
+              hydrated: true,
+              saving: false,
+              dirty: false,
+            },
+          };
+        });
+      })
+      .catch(() => {
+        // Fail open: mark hydrated so editing isn't blocked forever. The next
+        // edit will push and reconcile.
+        setEntries((prev) =>
+          prev[key]?.hydrated
+            ? prev
+            : { ...prev, [key]: { ...(prev[key] ?? FRESH), hydrated: true } },
+        );
+      })
+      .finally(() => hydrating.current.delete(key));
+  }, []);
+
+  const setAllocation = useCallback(
+    (
+      roundId: string,
+      userId: string,
+      updater: Updater<Record<string, number>>,
+    ) => {
+      const key = keyOf(roundId, userId);
+      versions.current.set(key, (versions.current.get(key) ?? 0) + 1);
+      setEntries((prev) => {
+        const cur = prev[key] ?? FRESH;
+        return {
+          ...prev,
+          [key]: { ...cur, allocation: updater(cur.allocation), dirty: true },
+        };
+      });
+      scheduleSave(roundId, userId);
+    },
+    [scheduleSave],
+  );
+
+  const setComments = useCallback(
+    (
+      roundId: string,
+      userId: string,
+      updater: Updater<Record<string, string>>,
+    ) => {
+      const key = keyOf(roundId, userId);
+      versions.current.set(key, (versions.current.get(key) ?? 0) + 1);
+      setEntries((prev) => {
+        const cur = prev[key] ?? FRESH;
+        return {
+          ...prev,
+          [key]: { ...cur, comments: updater(cur.comments), dirty: true },
+        };
+      });
+      scheduleSave(roundId, userId);
+    },
+    [scheduleSave],
+  );
+
+  // Called on submit: kill any pending debounced save so a stray write can't
+  // re-create the server row that submitVotes just deleted. Deliberately does
+  // NOT reset local state — the just-submitted allocation stays visible
+  // (read-only) until myVotes refetches and takes over, avoiding a 0-pts
+  // flicker. Once the user has voted the draft is ignored for editing anyway.
+  const cancelSave = useCallback((roundId: string, userId: string) => {
+    const key = keyOf(roundId, userId);
+    const t = timers.current.get(key);
+    if (t) {
+      clearTimeout(t);
+      timers.current.delete(key);
+    }
+    // Bump version so any in-flight save won't later mark the entry clean.
+    versions.current.set(key, (versions.current.get(key) ?? 0) + 1);
+  }, []);
+
+  const value = useMemo(
+    () => ({ entries, ensureHydrated, setAllocation, setComments, cancelSave }),
+    [entries, ensureHydrated, setAllocation, setComments, cancelSave],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+// Bound view of one (round, user) draft. Kicks off hydration on mount and
+// returns the local-authoritative allocation/comments plus sync status.
+export function useVotingDraftStore(
+  roundId: string | undefined,
+  userId: string | undefined,
+) {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useVotingDraftStore must be used within VotingDraftProvider");
+  }
+  const ready = !!roundId && !!userId;
+
+  useEffect(() => {
+    if (ready) ctx.ensureHydrated(roundId!, userId!);
+  }, [ready, roundId, userId, ctx]);
+
+  const key = ready ? keyOf(roundId!, userId!) : "";
+  const entry = (ready && ctx.entries[key]) || FRESH;
+
+  const setAllocation = useCallback(
+    (updater: Updater<Record<string, number>>) => {
+      if (ready) ctx.setAllocation(roundId!, userId!, updater);
+    },
+    [ctx, ready, roundId, userId],
+  );
+  const setComments = useCallback(
+    (updater: Updater<Record<string, string>>) => {
+      if (ready) ctx.setComments(roundId!, userId!, updater);
+    },
+    [ctx, ready, roundId, userId],
+  );
+  const cancelSave = useCallback(() => {
+    if (ready) ctx.cancelSave(roundId!, userId!);
+  }, [ctx, ready, roundId, userId]);
+
+  return {
+    allocation: entry.allocation,
+    comments: entry.comments,
+    hydrated: entry.hydrated,
+    saving: entry.saving,
+    dirty: entry.dirty,
+    setAllocation,
+    setComments,
+    cancelSave,
+  };
+}

--- a/apps/mobile/src/queries/keys.ts
+++ b/apps/mobile/src/queries/keys.ts
@@ -16,6 +16,10 @@ export const queryKeys = {
   roundVoters: (roundId: string) => ["round", roundId, "voters"] as const,
   submissionCounts: (roundIds: string[]) =>
     ["submissionCounts", ...roundIds.slice().sort()] as const,
+  // Resolves a submission back to its round (a submission's round never
+  // changes, so this is cached indefinitely).
+  submissionRound: (submissionId: string) =>
+    ["submission", submissionId, "round"] as const,
 
   // Season
   season: (seasonId: string) => ["season", seasonId] as const,

--- a/apps/mobile/src/queries/useSubmissionRoundId.ts
+++ b/apps/mobile/src/queries/useSubmissionRoundId.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSubmissionRoundId } from "@/services/submissions";
+import { queryKeys } from "./keys";
+
+// Resolves a submission id → its round id. A submission's round never changes,
+// so the result is cached indefinitely. Returns null when the id isn't a
+// submission (non-round playback source).
+export function useSubmissionRoundId(submissionId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.submissionRound(submissionId ?? ""),
+    queryFn: () => getSubmissionRoundId(submissionId!),
+    enabled: !!submissionId,
+    staleTime: Infinity,
+  });
+}

--- a/apps/mobile/src/queries/useVotingDraft.ts
+++ b/apps/mobile/src/queries/useVotingDraft.ts
@@ -1,0 +1,124 @@
+// High-level voting facade for surfaces that vote on a single track at a time
+// (the Now Playing modal). Composes the local-authoritative draft store with
+// the round's budget rules, the viewer's eligibility, and the submit path.
+//
+// The voting screen edits the same underlying draft directly via
+// `useVotingDraftStore`, so the two surfaces stay perfectly in sync.
+
+import { useCallback, useMemo } from "react";
+import { derivePhase } from "@/lib/utils/phase";
+import { useVotingDraftStore } from "@/context/VotingDraftContext";
+import { useRound } from "./useRound";
+import { useRoundSubmissions } from "./useRoundSubmissions";
+import { useMyVotes } from "./useMyVotes";
+import { useSubmitVotes } from "./useSubmitVotes";
+import type { VoteCommentInput, VoteInput } from "@/services/votes";
+
+export function useVotingDraft(
+  roundId: string | undefined,
+  userId: string | undefined,
+) {
+  const { data: round } = useRound(roundId);
+  const { data: submissions = [] } = useRoundSubmissions(roundId);
+  const { data: myVotes = {} } = useMyVotes(roundId, userId);
+  const store = useVotingDraftStore(roundId, userId);
+  const submit = useSubmitVotes();
+
+  const total = round?.seasons?.default_points_per_round ?? 10;
+  const maxPerTrack = round?.seasons?.default_max_points_per_track ?? 5;
+  const phase = round ? derivePhase(round) : null;
+  const isVoting = phase === "voting";
+
+  const didSubmit = !!userId && submissions.some((s) => s.user_id === userId);
+  const alreadyVoted = Object.keys(myVotes).length > 0;
+  // Editable only while voting is open, the viewer is a participant, hasn't
+  // voted yet, and the draft has hydrated (avoids editing on top of empty
+  // before the server draft loads).
+  const canEdit = isVoting && didSubmit && !alreadyVoted && store.hydrated;
+
+  const allocation = store.allocation;
+  const used = useMemo(
+    () => Object.values(allocation).reduce((a, b) => a + b, 0),
+    [allocation],
+  );
+  const remaining = total - used;
+
+  const adjust = useCallback(
+    (subId: string, delta: number) => {
+      if (!canEdit) return;
+      store.setAllocation((prev) => {
+        const cur = prev[subId] ?? 0;
+        const next = Math.max(0, Math.min(maxPerTrack, cur + delta));
+        const newUsed = used - cur + next;
+        if (newUsed > total) return prev;
+        return { ...prev, [subId]: next };
+      });
+    },
+    [canEdit, maxPerTrack, used, total, store],
+  );
+
+  const setComment = useCallback(
+    (subId: string, body: string) => {
+      store.setComments((prev) => ({ ...prev, [subId]: body }));
+    },
+    [store],
+  );
+
+  // Points to display: committed votes once submitted (read-only), otherwise
+  // the live draft.
+  const points = useCallback(
+    (subId: string) =>
+      alreadyVoted ? myVotes[subId] ?? 0 : allocation[subId] ?? 0,
+    [alreadyVoted, myVotes, allocation],
+  );
+  const comment = useCallback(
+    (subId: string) => store.comments[subId] ?? "",
+    [store.comments],
+  );
+  const isOwn = useCallback(
+    (subId: string) =>
+      submissions.some((s) => s.id === subId && s.user_id === userId),
+    [submissions, userId],
+  );
+
+  const canSubmit = canEdit && remaining === 0 && !submit.isPending;
+
+  const submitBallot = useCallback(async () => {
+    if (!roundId || !userId) return;
+    const votes: VoteInput[] = Object.entries(allocation)
+      .filter(([, pts]) => pts > 0)
+      .map(([submissionId, pts]) => ({ submissionId, points: pts }));
+    const comments: VoteCommentInput[] = Object.entries(store.comments)
+      .filter(([, body]) => body.trim().length > 0)
+      .map(([submissionId, body]) => ({ submissionId, body }));
+    // Kill the pending autosave first so it can't re-create the server draft
+    // that submitVotes deletes. Local state is left intact (read-only) until
+    // myVotes refetches.
+    store.cancelSave();
+    await submit.mutateAsync({ roundId, userId, votes, comments });
+  }, [roundId, userId, allocation, store, submit]);
+
+  return {
+    round,
+    phase,
+    isVoting,
+    didSubmit,
+    alreadyVoted,
+    canEdit,
+    total,
+    maxPerTrack,
+    used,
+    remaining,
+    points,
+    comment,
+    adjust,
+    setComment,
+    isOwn,
+    canSubmit,
+    submitting: submit.isPending,
+    saving: store.saving,
+    dirty: store.dirty,
+    hydrated: store.hydrated,
+    submitBallot,
+  };
+}

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -46,6 +46,7 @@ import { ChromeButton } from "@/ui/ChromeButton";
 import { HaloText } from "@/ui/HaloText";
 import { FittedChromeTitle } from "@/ui/FittedChromeTitle";
 import { useSession } from "@/context/SessionContext";
+import { useVotingDraftStore } from "@/context/VotingDraftContext";
 import { useRoundSubmissions } from "@/queries/useRoundSubmissions";
 import { useMyVotes } from "@/queries/useMyVotes";
 import { useSubmitVotes } from "@/queries/useSubmitVotes";
@@ -76,6 +77,7 @@ import { PageHeader } from "@/ui/PageHeader";
 import { HeroBanner } from "@/ui/cards/HeroBanner";
 import { TrackList, type TrackListItem } from "@/ui/sections/TrackList";
 import { useTabBarBottomInset } from "@/ui/hooks/useTabBarBottomInset";
+import { PODIUM_STOPS } from "@/ui/metalStops";
 import { derivePhase, formatPhaseCountdown } from "@/lib/utils/phase";
 import { roundCoverKey } from "@/lib/utils/coverKey";
 import { usePlayback, type PlaylistTrack } from "@/playback/PlaybackContext";
@@ -1063,24 +1065,19 @@ function VotingScreenContent({
   const pointsTotal = round.seasons?.default_points_per_round ?? 10;
   const maxPerTrack = round.seasons?.default_max_points_per_track ?? 5;
 
-  // Allocation seeds from myVotes on first render — but useMyVotes loads
-  // async, so the initial value is usually `{}`. Sync whenever myVotes
-  // changes (e.g. data lands after mount, or refetch on focus brings new
-  // server state). The "useState initializer runs once" rule was masking
-  // the loaded data and making the post-submit view show 0 pts everywhere.
-  const [allocation, setAllocation] = useState<Record<string, number>>(
-    () => myVotes,
-  );
-  const myVotesKey = JSON.stringify(myVotes);
-  useEffect(() => {
-    setAllocation(myVotes);
-    // myVotesKey gives us a stable signal that the contents (not just the
-    // object identity) actually changed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [myVotesKey]);
-  const [commentInputs, setCommentInputs] = useState<Record<string, string>>(
-    {},
-  );
+  // Allocation + comments live in the shared, server-persisted draft store
+  // (VotingDraftContext): edits autosave so progress survives an app kill, and
+  // the Now Playing modal edits the very same draft. The store is local-
+  // authoritative — it hydrates from the server once, then never gets clobbered
+  // by a refetch. The committed/locked view reads myVotes directly (below).
+  const {
+    allocation,
+    comments: commentInputs,
+    setAllocation,
+    setComments: setCommentInputs,
+    hydrated: draftHydrated,
+    cancelSave: cancelDraftSave,
+  } = useVotingDraftStore(round.id, userId);
   // Per-submission state for the comment draft.
   //   savedCommentIds — slot has a stowed comment (icon goes solid). Stays
   //     set while the user is editing so the indicator doesn't flicker.
@@ -1108,7 +1105,10 @@ function VotingScreenContent({
   const remaining = pointsTotal - used;
   const alreadyVoted = Object.keys(myVotes).length > 0;
   const showSubmittedView = alreadyVoted || justSubmitted;
-  const canEdit = didSubmit && !isSpectator && !showSubmittedView;
+  // Wait for the draft to hydrate before enabling edits, so we never start
+  // adjusting on top of an empty allocation before the saved draft loads.
+  const canEdit =
+    didSubmit && !isSpectator && !showSubmittedView && draftHydrated;
 
   // Build the orderable playlist (skip own track from playable queue is OK —
   // user can still hear it via the round's own playback context).
@@ -1185,6 +1185,10 @@ function VotingScreenContent({
     const comments: VoteCommentInput[] = submissions
       .filter((s) => (commentInputs[s.id] ?? "").trim().length > 0)
       .map((s) => ({ submissionId: s.id, body: commentInputs[s.id] }));
+
+    // Kill any pending autosave so it can't re-create the server draft that
+    // submitVotes deletes once the real ballot lands.
+    cancelDraftSave();
 
     try {
       await submitMutation.mutateAsync({
@@ -1322,7 +1326,11 @@ function VotingScreenContent({
 
         {submissions.map((sub, idx) => {
           const trackNum = String(idx + 1).padStart(2, "0");
-          const pts = allocation[sub.id] ?? 0;
+          // While editing, show the live draft; in the locked/submitted view
+          // show committed votes (falling back to the draft until myVotes
+          // refetches, so the count never blinks to 0 right after submitting).
+          const draftPts = allocation[sub.id] ?? 0;
+          const pts = showSubmittedView ? myVotes[sub.id] ?? draftPts : draftPts;
           const isOwn = sub.user_id === userId;
           const plusDisabled =
             submitting ||
@@ -2159,44 +2167,6 @@ type VoterRow = {
   voter_name: string;
   points: number;
   comment: string | null;
-};
-
-// Metal palettes — same shape as ChromeBorder's default; passed in to draw
-// gold and bronze variants with the same polished-metal feel. Stops ramp
-// light → mid → light → dark → light → mid so the gradient reads as
-// hammered metal at any size.
-const CHROME_STOPS = [
-  "#f5f5f5",
-  "#d0d0d0",
-  "#ffffff",
-  "#b0b0b0",
-  "#e8e8e8",
-  "#c8c8c8",
-] as const;
-// Lighter champagne-gold variant — every stop pulled up a step so the dark
-// banding doesn't drag the average tone into a muddy mustard.
-const GOLD_STOPS = [
-  "#FFF0B0",
-  "#E5BE54",
-  "#FFF7CC",
-  "#D6A742",
-  "#F5D27E",
-  "#E5BE54",
-] as const;
-// Lighter rose-bronze / copper variant. Same logic — the deep brown stops
-// were eating the highlight; replaced with warmer mid-coppers.
-const BRONZE_STOPS = [
-  "#F2CBA1",
-  "#C58A60",
-  "#F9DCBC",
-  "#B07847",
-  "#DBA478",
-  "#C58A60",
-] as const;
-const PODIUM_STOPS: Record<1 | 2 | 3, readonly string[]> = {
-  1: GOLD_STOPS,
-  2: CHROME_STOPS,
-  3: BRONZE_STOPS,
 };
 
 // Per-rank sizing tuned to match Claude Design's podium reference: 1st's art

--- a/apps/mobile/src/services/submissions.ts
+++ b/apps/mobile/src/services/submissions.ts
@@ -132,3 +132,20 @@ export async function getSubmissionCountsForRounds(
   }
   return counts;
 }
+
+// Resolve a submission's owning round id. Used by surfaces that only hold a
+// submission id (e.g. the Now Playing modal, where a PlaylistTrack.id IS a
+// submission id) and need to look up the round's phase / results / voters.
+// Returns null when the id isn't a submission (e.g. a non-round playback
+// source), so callers can fall back to a plain player with no round panel.
+export async function getSubmissionRoundId(
+  submissionId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("submissions")
+    .select("round_id")
+    .eq("id", submissionId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  return (data as { round_id: string } | null)?.round_id ?? null;
+}

--- a/apps/mobile/src/services/voteDrafts.ts
+++ b/apps/mobile/src/services/voteDrafts.ts
@@ -1,0 +1,67 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+// In-progress (unsubmitted) ballot for a round, persisted server-side so a
+// voter's allocation + comments survive an app kill. Two maps keyed by
+// submission id. See migration 20260530000000_vote_drafts.sql.
+export type VoteDraft = {
+  allocation: Record<string, number>;
+  comments: Record<string, string>;
+};
+
+export const EMPTY_VOTE_DRAFT: VoteDraft = { allocation: {}, comments: {} };
+
+// `packages/db/types.ts` is stale and doesn't know about vote_drafts yet, so
+// the typed client can't resolve the table. Cast through a minimal shape —
+// same tech-debt workaround the rest of the services use (regenerate types
+// with `pnpm gen-types` once the migration is applied).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sb = supabase as any;
+
+export async function getVoteDraft(
+  roundId: string,
+  userId: string,
+): Promise<VoteDraft> {
+  const { data, error } = await sb
+    .from("vote_drafts")
+    .select("allocation, comments")
+    .eq("round_id", roundId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw postgresToMixError(error);
+  if (!data) return { allocation: {}, comments: {} };
+  return {
+    allocation: (data.allocation as Record<string, number>) ?? {},
+    comments: (data.comments as Record<string, string>) ?? {},
+  };
+}
+
+export async function saveVoteDraft(
+  roundId: string,
+  userId: string,
+  draft: VoteDraft,
+): Promise<void> {
+  const { error } = await sb.from("vote_drafts").upsert(
+    {
+      round_id: roundId,
+      user_id: userId,
+      allocation: draft.allocation,
+      comments: draft.comments,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "round_id,user_id" },
+  );
+  if (error) throw postgresToMixError(error);
+}
+
+export async function clearVoteDraft(
+  roundId: string,
+  userId: string,
+): Promise<void> {
+  const { error } = await sb
+    .from("vote_drafts")
+    .delete()
+    .eq("round_id", roundId)
+    .eq("user_id", userId);
+  if (error) throw postgresToMixError(error);
+}

--- a/apps/mobile/src/services/votes.ts
+++ b/apps/mobile/src/services/votes.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabase";
 import { postgresToMixError, UnknownMixError } from "./errors";
+import { clearVoteDraft } from "./voteDrafts";
 
 // The voter's view of a submission. Intentionally narrower than the full row —
 // results phase reads more columns via its own service when we get there.
@@ -97,5 +98,14 @@ export async function submitVotes(args: SubmitVotesArgs): Promise<void> {
         { cause: commentError },
       );
     }
+  }
+
+  // The real ballot is in now — drop the persisted draft so it can't resurface.
+  // Best-effort: a lingering draft is ignored once the user has voted, so a
+  // failure here isn't worth surfacing to the caller.
+  try {
+    await clearVoteDraft(args.roundId, args.userId);
+  } catch {
+    // ignore — draft cleanup is non-critical
   }
 }

--- a/apps/mobile/src/ui/ChromeText.tsx
+++ b/apps/mobile/src/ui/ChromeText.tsx
@@ -19,6 +19,11 @@ export type ChromeGlyphProps = {
   glyph: string;
   size?: number;
   style?: StyleProp<ViewStyle>;
+  // Override the metal palette (defaults to chrome silver). Pass GOLD_STOPS /
+  // BRONZE_STOPS from `@/ui/metalStops` for medal variants. When `colors` is
+  // given without `colorLocations`, the gradient distributes the stops evenly.
+  colors?: readonly string[];
+  colorLocations?: readonly number[];
 };
 
 const CHROME_COLORS = [
@@ -31,12 +36,26 @@ const CHROME_COLORS = [
 ] as const;
 const CHROME_LOCATIONS = [0, 0.25, 0.45, 0.6, 0.8, 1] as const;
 
-export function ChromeText({ glyph, size = 24, style }: ChromeGlyphProps) {
+export function ChromeText({
+  glyph,
+  size = 24,
+  style,
+  colors,
+  colorLocations,
+}: ChromeGlyphProps) {
   // The mask glyph needs a generous bounding box so descenders / wide glyphs
   // (★ has the same width as height; ✦ slightly wider) don't clip. 1.2× is a
   // safe envelope that still hugs the character visually.
   const boxW = Math.round(size * 1.2);
   const boxH = Math.round(size * 1.2);
+
+  const gradientColors = (colors ??
+    CHROME_COLORS) as unknown as [string, string, ...string[]];
+  // Match ChromeBorder: keep the tuned silver stops for the default palette,
+  // but let a custom palette distribute evenly unless caller overrides.
+  const gradientLocations = (
+    colors !== undefined ? colorLocations : CHROME_LOCATIONS
+  ) as unknown as [number, number, ...number[]] | undefined;
 
   return (
     <MaskedView
@@ -54,8 +73,8 @@ export function ChromeText({ glyph, size = 24, style }: ChromeGlyphProps) {
       }
     >
       <LinearGradient
-        colors={CHROME_COLORS as unknown as [string, string, ...string[]]}
-        locations={CHROME_LOCATIONS as unknown as [number, number, ...number[]]}
+        colors={gradientColors}
+        locations={gradientLocations}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 1 }}
         style={StyleSheet.absoluteFill}

--- a/apps/mobile/src/ui/metalStops.ts
+++ b/apps/mobile/src/ui/metalStops.ts
@@ -1,0 +1,43 @@
+// Polished-metal gradient palettes shared by chrome glyphs, borders, and
+// podium rings. Stops ramp light → mid → light → dark → light → mid so the
+// gradient reads as hammered metal at any size. Used by ChromeText /
+// ChromeBorder (silver default) and by rank/medal treatments (gold/silver/
+// bronze) on the results, podium, and Now Playing surfaces.
+
+export const CHROME_STOPS = [
+  "#f5f5f5",
+  "#d0d0d0",
+  "#ffffff",
+  "#b0b0b0",
+  "#e8e8e8",
+  "#c8c8c8",
+] as const;
+
+// Lighter champagne-gold variant — every stop pulled up a step so the dark
+// banding doesn't drag the average tone into a muddy mustard.
+export const GOLD_STOPS = [
+  "#FFF0B0",
+  "#E5BE54",
+  "#FFF7CC",
+  "#D6A742",
+  "#F5D27E",
+  "#E5BE54",
+] as const;
+
+// Lighter rose-bronze / copper variant. Same logic — the deep brown stops
+// were eating the highlight; replaced with warmer mid-coppers.
+export const BRONZE_STOPS = [
+  "#F2CBA1",
+  "#C58A60",
+  "#F9DCBC",
+  "#B07847",
+  "#DBA478",
+  "#C58A60",
+] as const;
+
+// 1st = gold, 2nd = silver (default chrome), 3rd = bronze.
+export const PODIUM_STOPS: Record<1 | 2 | 3, readonly string[]> = {
+  1: GOLD_STOPS,
+  2: CHROME_STOPS,
+  3: BRONZE_STOPS,
+};

--- a/packages/db/types.ts
+++ b/packages/db/types.ts
@@ -725,6 +725,7 @@ export type Database = {
           id: string
           playlist_position: number | null
           round_id: string
+          soundcloud_track_url: string | null
           spotify_track_id: string | null
           track_album_name: string | null
           track_artist: string
@@ -734,6 +735,7 @@ export type Database = {
           track_isrc: string
           track_popularity: number | null
           track_release_year: number | null
+          track_source: string
           track_title: string
           user_id: string
         }
@@ -744,6 +746,7 @@ export type Database = {
           id?: string
           playlist_position?: number | null
           round_id: string
+          soundcloud_track_url?: string | null
           spotify_track_id?: string | null
           track_album_name?: string | null
           track_artist: string
@@ -753,6 +756,7 @@ export type Database = {
           track_isrc: string
           track_popularity?: number | null
           track_release_year?: number | null
+          track_source?: string
           track_title: string
           user_id: string
         }
@@ -763,6 +767,7 @@ export type Database = {
           id?: string
           playlist_position?: number | null
           round_id?: string
+          soundcloud_track_url?: string | null
           spotify_track_id?: string | null
           track_album_name?: string | null
           track_artist?: string
@@ -772,6 +777,7 @@ export type Database = {
           track_isrc?: string
           track_popularity?: number | null
           track_release_year?: number | null
+          track_source?: string
           track_title?: string
           user_id?: string
         }
@@ -818,6 +824,45 @@ export type Database = {
           spotify_id?: string | null
         }
         Relationships: []
+      }
+      vote_drafts: {
+        Row: {
+          allocation: Json
+          comments: Json
+          round_id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          allocation?: Json
+          comments?: Json
+          round_id: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          allocation?: Json
+          comments?: Json
+          round_id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vote_drafts_round_id_fkey"
+            columns: ["round_id"]
+            isOneToOne: false
+            referencedRelation: "rounds"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vote_drafts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       votes: {
         Row: {

--- a/supabase/migrations/20260530000000_vote_drafts.sql
+++ b/supabase/migrations/20260530000000_vote_drafts.sql
@@ -1,0 +1,41 @@
+-- ─── vote_drafts ──────────────────────────────────────────────────────────────
+-- Per (round, user) in-progress ballot, autosaved from the client so that
+-- voting + commenting progress survives an app kill *before* the user submits.
+-- One row per voter per round; the whole draft is stored as two JSONB maps so
+-- the client can upsert it in a single debounced write:
+--   allocation: { "<submission_id>": <points> }
+--   comments:   { "<submission_id>": "<body>" }
+-- The draft is private to its owner and is cleared once the user submits their
+-- real votes via submit_votes (the client deletes it; a stray row is harmless
+-- because the app ignores the draft once the user has voted).
+
+create table public.vote_drafts (
+  round_id   uuid not null references public.rounds(id) on delete cascade,
+  user_id    uuid not null references public.users(id) on delete cascade,
+  allocation jsonb not null default '{}'::jsonb,
+  comments   jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now(),
+  primary key (round_id, user_id)
+);
+
+alter table public.vote_drafts enable row level security;
+
+-- Drafts are strictly private: a user can only ever see / write / delete their
+-- own. No league-member read policy (unlike votes/comments) — an unsubmitted
+-- ballot is nobody else's business.
+create policy "Users can view own vote draft"
+  on public.vote_drafts for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own vote draft"
+  on public.vote_drafts for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own vote draft"
+  on public.vote_drafts for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own vote draft"
+  on public.vote_drafts for delete
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
Rebuilds the full-screen **Now Playing** page on the iridescent/bubblegum theme and turns it into a voting surface.

### Now Playing layout & motion
- Iridescent `Wallpaper` backdrop, grab handle (chevron removed), classic `Rewind`/`FastForward` transport above a full-width scrubber (elapsed left / remaining right).
- Album art **animates with play state**: springy bounce on grow, smooth on shrink. Layout always reserves the large footprint so the **title/artist line never shifts**. A soft plum **"lift" shadow fades in only at the large size** — and the whole thing runs on the native driver (scale + a cross-faded shadow plate) so it's smooth.
- Left-aligned title/artist with a trailing "more" button; controls vertically centered in the space below the art.

### Completed-round panel
- 3-column row keeps the **score pill centered** regardless of rank/comment widths.
- **Medal stars**: gold/silver/bronze chrome star for ranks 1/2/3, number-only for 4+.
- Read-only voter-comments accordion (same shape as the playlist screen).

### Vote-as-you-listen (backend-persisted drafts)
- New **`vote_drafts`** table (`round_id`, `user_id`, `allocation`/`comments` jsonb) with **owner-only RLS** — unsubmitted ballots survive an app kill.
- **`VotingDraftContext`**: local-authoritative store (hydrate once, then never clobbered by a refetch — avoids the ballot "falling behind" desync) with **debounced autosave** + background flush. Shared by the voting screen and the modal so they stay in lockstep.
- Modal voting panel: per-track **steppers + inline comment composer + Submit ballot** (enabled once the whole budget is allocated); read-only once voted. The all-or-nothing `submit_votes` contract is satisfied by accumulating the draft across the playlist.
- `RoundScreen` voting refactored onto the shared draft; submit clears the draft.

### Shared / housekeeping
- Extracted gold/silver/bronze metal palettes to `ui/metalStops.ts`; `ChromeText` now accepts a custom palette.
- Regenerated `packages/db/types.ts` for `vote_drafts` (+ catch-up soundcloud columns).

## Notes
- The `vote_drafts` migration has been applied and types regenerated (`pnpm db:push`).
- **Excluded `pnpm-lock.yaml`** from this PR — it currently has unresolved merge-conflict markers (a `react-native-svg` specifier conflict) unrelated to this work; worth resolving separately.

## Test plan
- `pnpm --filter @mix/mobile type-check` passes.
- Manual: play/pause grow/shrink + lift shadow; swipe between tracks; completed round shows rank/score/comments; during voting, allocate across the playlist (steppers + comment) and confirm autosave persists across an app kill, then submit and verify lock + draft cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)