### PR TITLE
Use native iOS tabs for playback chrome

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,11 +1,13 @@
 import { Tabs } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MixTabBar } from '@/ui/nav/MixTabBar';
 import { NowPlayingPillConnected } from '@/components/NowPlayingPillConnected';
 import { THEME } from '@/ui/theme/tokens';
 
 export default function TabsLayout() {
+  const insets = useSafeAreaInsets();
+
   return (
     <View style={styles.root}>
       <Tabs
@@ -15,16 +17,18 @@ export default function TabsLayout() {
           sceneStyle: { backgroundColor: THEME.bg },
         }}
         tabBar={(props) => (
-          <SafeAreaView
-            style={styles.bottomChrome}
-            edges={['bottom']}
+          <View
+            style={[
+              styles.bottomChrome,
+              { paddingBottom: Math.max(insets.bottom - 14, 4) },
+            ]}
             pointerEvents="box-none"
           >
             <View style={styles.chromeStack} pointerEvents="box-none">
               <NowPlayingPillConnected />
               <MixTabBar {...props} />
             </View>
-          </SafeAreaView>
+          </View>
         )}
       >
         <Tabs.Screen name="(home)" options={{ title: 'Home' }} />
@@ -42,7 +46,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    paddingBottom: 6,
   },
-  chromeStack: { gap: 8 },
+  chromeStack: { gap: 6 },
 });

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,51 +1,82 @@
-import { Tabs } from 'expo-router';
+import {
+  NativeTabs,
+  NativeTabTrigger,
+} from 'expo-router/unstable-native-tabs';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { MixTabBar } from '@/ui/nav/MixTabBar';
 import { NowPlayingPillConnected } from '@/components/NowPlayingPillConnected';
 import { THEME } from '@/ui/theme/tokens';
+import {
+  FLOATING_CHROME_GAP,
+  NATIVE_TAB_BAR_HEIGHT,
+} from '@/ui/nav/floatingChromeMetrics';
+
+const ACTIVE_RED = '#FC3C44';
 
 export default function TabsLayout() {
   const insets = useSafeAreaInsets();
 
   return (
     <View style={styles.root}>
-      <Tabs
-        screenOptions={{
-          headerShown: false,
-          tabBarStyle: { display: 'none' },
-          sceneStyle: { backgroundColor: THEME.bg },
-        }}
-        tabBar={(props) => (
-          <View
-            style={[
-              styles.bottomChrome,
-              { paddingBottom: Math.max(insets.bottom - 14, 4) },
-            ]}
-            pointerEvents="box-none"
-          >
-            <View style={styles.chromeStack} pointerEvents="box-none">
-              <NowPlayingPillConnected />
-              <MixTabBar {...props} />
-            </View>
-          </View>
-        )}
+      <NativeTabs tintColor={ACTIVE_RED}>
+        <NativeTabTrigger
+          name="(home)"
+          options={{
+            title: 'Home',
+            icon: { sf: 'house.fill' },
+          }}
+        />
+        <NativeTabTrigger
+          name="mix"
+          options={{
+            title: 'Mix',
+            icon: { sf: 'music.note' },
+          }}
+        />
+        <NativeTabTrigger
+          name="activity"
+          options={{
+            title: 'Activity',
+            icon: { sf: 'chart.bar.fill' },
+          }}
+        />
+        <NativeTabTrigger
+          name="profile"
+          options={{
+            title: 'Profile',
+            icon: { sf: 'person.fill' },
+          }}
+        />
+        <NativeTabTrigger
+          name="search"
+          options={{
+            title: 'Search',
+            icon: { sf: 'magnifyingglass' },
+          }}
+        />
+      </NativeTabs>
+
+      <View
+        style={[
+          styles.pillOverlay,
+          {
+            bottom:
+              NATIVE_TAB_BAR_HEIGHT + insets.bottom + FLOATING_CHROME_GAP,
+          },
+        ]}
+        pointerEvents="box-none"
       >
-        <Tabs.Screen name="(home)" options={{ title: 'Home' }} />
-        <Tabs.Screen name="mix" options={{ title: 'Mix' }} />
-        <Tabs.Screen name="profile" options={{ title: 'Profile' }} />
-      </Tabs>
+        <NowPlayingPillConnected />
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: THEME.bg },
-  bottomChrome: {
+  pillOverlay: {
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 0,
   },
-  chromeStack: { gap: 6 },
 });

--- a/apps/mobile/src/app/(tabs)/activity.tsx
+++ b/apps/mobile/src/app/(tabs)/activity.tsx
@@ -1,0 +1,15 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { THEME } from '@/ui/theme/tokens';
+
+export default function ActivityPage() {
+  return (
+    <View style={styles.root}>
+      <Text style={styles.text}>Activity</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: THEME.bg, alignItems: 'center', justifyContent: 'center' },
+  text: { fontFamily: THEME.fonts.sansSemi, fontSize: 18, color: THEME.ink },
+});

--- a/apps/mobile/src/app/(tabs)/search.tsx
+++ b/apps/mobile/src/app/(tabs)/search.tsx
@@ -1,0 +1,15 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { THEME } from '@/ui/theme/tokens';
+
+export default function SearchPage() {
+  return (
+    <View style={styles.root}>
+      <Text style={styles.text}>Search</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: THEME.bg, alignItems: 'center', justifyContent: 'center' },
+  text: { fontFamily: THEME.fonts.sansSemi, fontSize: 18, color: THEME.ink },
+});

--- a/apps/mobile/src/ui/hooks/useTabBarBottomInset.ts
+++ b/apps/mobile/src/ui/hooks/useTabBarBottomInset.ts
@@ -3,25 +3,19 @@
 // behind the floating chrome.
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-
-/** Visual height of the tab bar pill (matches MixTabBar layout). */
-export const TAB_BAR_HEIGHT = 56;
-
-/** Visual height of the now-playing pill (matches NowPlayingPill layout). */
-export const NOW_PLAYING_PILL_HEIGHT = 60;
-
-/** Gap between the now-playing pill and the tab bar. */
-export const FLOATING_CHROME_GAP = 8;
-
-/** Extra breathing room above the topmost floating element. */
-export const FLOATING_CHROME_TOP_PAD = 8;
+import {
+  FLOATING_CHROME_GAP,
+  FLOATING_CHROME_TOP_PAD,
+  NATIVE_TAB_BAR_HEIGHT,
+  NOW_PLAYING_PILL_HEIGHT,
+} from '@/ui/nav/floatingChromeMetrics';
 
 export function useTabBarBottomInset(opts?: { withNowPlaying?: boolean }) {
   const insets = useSafeAreaInsets();
   const withNowPlaying = opts?.withNowPlaying ?? true;
   return (
     insets.bottom +
-    TAB_BAR_HEIGHT +
+    NATIVE_TAB_BAR_HEIGHT +
     (withNowPlaying ? NOW_PLAYING_PILL_HEIGHT + FLOATING_CHROME_GAP : 0) +
     FLOATING_CHROME_TOP_PAD
   );

--- a/apps/mobile/src/ui/nav/MixTabBar.tsx
+++ b/apps/mobile/src/ui/nav/MixTabBar.tsx
@@ -1,24 +1,11 @@
-import { useEffect, useRef, useState } from "react";
-import {
-  Animated,
-  PanResponder,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
-import { House, Music, User } from "lucide-react-native";
-import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
-import { GlassSurface } from "@/ui/glass/GlassSurface";
-import { THEME } from "@/ui/theme/tokens";
+// Liquid-glass floating tab bar — Apple Music style. Adapts BottomTabBarProps
+// from React Navigation into the same visual treatment as the preview's
+// `_TabBar.tsx`. Three tabs only: Home / Mix / Profile.
 
-const ACTIVE_RED = "#FC3C44";
-const INACTIVE = THEME.ink;
-const ROW_H_PAD = 6;
-const ROW_V_PAD = 8;
-const INDICATOR_INSET = 2;
-const INDICATOR_V_INSET = 6;
-const FLICK_VX = 0.5;
+import { BlurView } from "expo-blur";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { THEME } from "@/ui/theme/tokens";
 
 type TabConfig = {
   label: string;
@@ -28,223 +15,34 @@ type TabConfig = {
 const TAB_CONFIG: Record<string, TabConfig> = {
   "(home)": {
     label: "Home",
-    icon: (active) => (
-      <House
-        size={22}
-        color={active ? ACTIVE_RED : INACTIVE}
-        fill={active ? ACTIVE_RED : INACTIVE}
-        strokeWidth={1.5}
-      />
-    ),
+    icon: (active) => <HomeIcon color={active ? THEME.accent : THEME.ink} />,
   },
   mix: {
     label: "Mix",
-    icon: (active) => (
-      <Music
-        size={22}
-        color={active ? ACTIVE_RED : INACTIVE}
-        fill={active ? ACTIVE_RED : INACTIVE}
-        strokeWidth={1.5}
-      />
-    ),
+    icon: (active) => <NoteIcon color={active ? THEME.accent : THEME.ink} />,
   },
   profile: {
     label: "Profile",
-    icon: (active) => (
-      <User
-        size={22}
-        color={active ? ACTIVE_RED : INACTIVE}
-        fill={active ? ACTIVE_RED : INACTIVE}
-        strokeWidth={1.5}
-      />
-    ),
+    icon: (active) => <PersonIcon color={active ? THEME.accent : THEME.ink} />,
   },
 };
 
 export function MixTabBar({ state, navigation }: BottomTabBarProps) {
-  const [rowWidth, setRowWidth] = useState(0);
-  const [displayIndex, setDisplayIndex] = useState(state.index);
-  const slideAnim = useRef(new Animated.Value(0)).current;
-  const scaleAnim = useRef(new Animated.Value(1)).current;
-  const mounted = useRef(false);
-
-  const tabCount = state.routes.length;
-  const contentWidth = rowWidth - ROW_H_PAD * 2;
-  const tabWidth = contentWidth / tabCount;
-
-  // Sync displayIndex when tab changes via press
-  useEffect(() => {
-    setDisplayIndex(state.index);
-    displayIdxRef.current = state.index;
-  }, [state.index]);
-
-  // Refs for stable access inside PanResponder closures
-  const twRef = useRef(tabWidth);
-  const tcRef = useRef(tabCount);
-  const idxRef = useRef(state.index);
-  const routesRef = useRef(state.routes);
-  const navRef = useRef(navigation);
-  const displayIdxRef = useRef(state.index);
-  twRef.current = tabWidth;
-  tcRef.current = tabCount;
-  idxRef.current = state.index;
-  routesRef.current = state.routes;
-  navRef.current = navigation;
-
-  const posFor = (i: number) =>
-    ROW_H_PAD + i * twRef.current + INDICATOR_INSET;
-
-  const dragStart = useRef(0);
-
-  const pan = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponderCapture: (_, gs) =>
-        twRef.current > 0 && Math.abs(gs.dx) > 8,
-      onPanResponderGrant: () => {
-        dragStart.current = idxRef.current;
-        Animated.spring(scaleAnim, {
-          toValue: 1.2,
-          useNativeDriver: true,
-          tension: 300,
-          friction: 12,
-        }).start();
-      },
-      onPanResponderMove: (_, gs) => {
-        const tw = twRef.current;
-        const tc = tcRef.current;
-        const raw = dragStart.current * tw + gs.dx;
-        const clamped = Math.max(0, Math.min((tc - 1) * tw, raw));
-        slideAnim.setValue(ROW_H_PAD + clamped + INDICATOR_INSET);
-
-        const nearest = Math.round(
-          Math.max(0, Math.min(tc - 1, clamped / tw)),
-        );
-        if (nearest !== displayIdxRef.current) {
-          displayIdxRef.current = nearest;
-          setDisplayIndex(nearest);
-        }
-      },
-      onPanResponderRelease: (_, gs) => {
-        const tw = twRef.current;
-        const tc = tcRef.current;
-        const raw = dragStart.current * tw + gs.dx;
-
-        let target: number;
-        if (Math.abs(gs.vx) > FLICK_VX) {
-          target =
-            gs.vx > 0
-              ? Math.min(tc - 1, dragStart.current + 1)
-              : Math.max(0, dragStart.current - 1);
-        } else {
-          target = Math.round(Math.max(0, Math.min(tc - 1, raw / tw)));
-        }
-
-        displayIdxRef.current = target;
-        setDisplayIndex(target);
-
-        Animated.parallel([
-          Animated.spring(slideAnim, {
-            toValue: ROW_H_PAD + target * tw + INDICATOR_INSET,
-            useNativeDriver: true,
-            tension: 180,
-            friction: 15,
-          }),
-          Animated.spring(scaleAnim, {
-            toValue: 1,
-            useNativeDriver: true,
-            tension: 180,
-            friction: 14,
-          }),
-        ]).start();
-
-        if (target !== idxRef.current) {
-          const route = routesRef.current[target];
-          if (route) navRef.current.navigate(route.name as never);
-        }
-      },
-      onPanResponderTerminate: () => {
-        displayIdxRef.current = idxRef.current;
-        setDisplayIndex(idxRef.current);
-
-        Animated.parallel([
-          Animated.spring(slideAnim, {
-            toValue: posFor(idxRef.current),
-            useNativeDriver: true,
-            tension: 300,
-            friction: 25,
-          }),
-          Animated.spring(scaleAnim, {
-            toValue: 1,
-            useNativeDriver: true,
-            tension: 300,
-            friction: 20,
-          }),
-        ]).start();
-      },
-    }),
-  ).current;
-
-  useEffect(() => {
-    if (!rowWidth) return;
-    const toValue = posFor(state.index);
-    if (!mounted.current) {
-      slideAnim.setValue(toValue);
-      mounted.current = true;
-      return;
-    }
-    Animated.spring(slideAnim, {
-      toValue,
-      useNativeDriver: true,
-      tension: 280,
-      friction: 22,
-    }).start();
-  }, [state.index, tabWidth]);
-
   return (
     <View style={styles.wrap}>
-      <GlassSurface glassEffectStyle="regular" interactive style={styles.pill}>
-        <View
-          style={styles.row}
-          onLayout={(e) => setRowWidth(e.nativeEvent.layout.width)}
-          {...pan.panHandlers}
-        >
-          {rowWidth > 0 && (
-            <Animated.View
-              style={[
-                styles.indicator,
-                {
-                  width: tabWidth - INDICATOR_INSET * 2,
-                  transform: [
-                    { translateX: slideAnim },
-                    { scaleY: scaleAnim },
-                  ],
-                },
-              ]}
-            >
-              <GlassSurface
-                glassEffectStyle="clear"
-                interactive
-                tintColor="rgba(255,255,255,0.35)"
-                style={styles.indicatorGlass}
-              >
-                <View style={styles.indicatorFill} />
-              </GlassSurface>
-            </Animated.View>
-          )}
-
+      <BlurView intensity={55} tint="light" style={styles.pill}>
+        <View style={styles.row}>
           {state.routes.map((route, index) => {
             const config = TAB_CONFIG[route.name];
             if (!config) return null;
-            const focused = displayIndex === index;
+            const focused = state.index === index;
             const onPress = () => {
               const event = navigation.emit({
                 type: "tabPress",
                 target: route.key,
                 canPreventDefault: true,
               });
-              if (state.index !== index && !event.defaultPrevented) {
+              if (!focused && !event.defaultPrevented) {
                 navigation.navigate(route.name as never);
               }
             };
@@ -257,12 +55,14 @@ export function MixTabBar({ state, navigation }: BottomTabBarProps) {
                 accessibilityRole="button"
                 accessibilityState={focused ? { selected: true } : {}}
               >
-                <View style={styles.itemInner}>
+                <View
+                  style={[styles.itemInner, focused && styles.itemInnerActive]}
+                >
                   {config.icon(focused)}
                   <Text
                     style={[
                       styles.label,
-                      { color: focused ? ACTIVE_RED : INACTIVE },
+                      { color: focused ? THEME.accent : THEME.ink },
                     ]}
                   >
                     {config.label}
@@ -272,48 +72,47 @@ export function MixTabBar({ state, navigation }: BottomTabBarProps) {
             );
           })}
         </View>
-      </GlassSurface>
+      </BlurView>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  wrap: {
-    paddingHorizontal: 10,
-    shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
+// ── Icons ────────────────────────────────────────────────────────────
+// Glyph icons to match the preview's style — no extra dependencies.
+
+function HomeIcon({ color }: { color: string }) {
+  return <Text style={[iconStyles.char, { color }]}>⌂</Text>;
+}
+function NoteIcon({ color }: { color: string }) {
+  return <Text style={[iconStyles.char, { color }]}>♫</Text>;
+}
+function PersonIcon({ color }: { color: string }) {
+  return <Text style={[iconStyles.char, { color }]}>☻</Text>;
+}
+
+const iconStyles = StyleSheet.create({
+  char: {
+    fontSize: 22,
+    fontWeight: "700",
+    lineHeight: 24,
   },
+});
+
+const styles = StyleSheet.create({
+  wrap: { paddingHorizontal: 10 },
   pill: {
     borderRadius: 32,
     overflow: "hidden",
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(255,255,255,0.25)",
+    borderColor: "rgba(11,11,11,0.06)",
   },
   row: {
     flexDirection: "row",
-    paddingHorizontal: ROW_H_PAD,
-    paddingVertical: ROW_V_PAD,
+    paddingHorizontal: 6,
+    paddingVertical: 8,
+    backgroundColor: "rgba(246,241,232,0.5)",
   },
-  indicator: {
-    position: "absolute",
-    top: INDICATOR_V_INSET,
-    bottom: INDICATOR_V_INSET,
-    borderRadius: 26,
-    overflow: "hidden",
-  },
-  indicatorGlass: {
-    flex: 1,
-    borderRadius: 26,
-    overflow: "hidden",
-  },
-  indicatorFill: {
-    flex: 1,
-    backgroundColor: "rgba(255,255,255,0.12)",
-  },
-  item: { flex: 1, alignItems: "center", zIndex: 1 },
+  item: { flex: 1, alignItems: "center" },
   itemInner: {
     alignItems: "center",
     justifyContent: "center",
@@ -321,6 +120,9 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     borderRadius: 18,
     gap: 2,
+  },
+  itemInnerActive: {
+    backgroundColor: "rgba(176,42,42,0.10)",
   },
   label: {
     ...THEME.text.tabLabel,

--- a/apps/mobile/src/ui/nav/MixTabBar.tsx
+++ b/apps/mobile/src/ui/nav/MixTabBar.tsx
@@ -1,11 +1,24 @@
-// Liquid-glass floating tab bar — Apple Music style. Adapts BottomTabBarProps
-// from React Navigation into the same visual treatment as the preview's
-// `_TabBar.tsx`. Three tabs only: Home / Mix / Profile.
-
-import { BlurView } from "expo-blur";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { House, Music, User } from "lucide-react-native";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { GlassSurface } from "@/ui/glass/GlassSurface";
 import { THEME } from "@/ui/theme/tokens";
+
+const ACTIVE_RED = "#FC3C44";
+const INACTIVE = THEME.ink;
+const ROW_H_PAD = 6;
+const ROW_V_PAD = 8;
+const INDICATOR_INSET = 2;
+const INDICATOR_V_INSET = 6;
+const FLICK_VX = 0.5;
 
 type TabConfig = {
   label: string;
@@ -15,34 +28,223 @@ type TabConfig = {
 const TAB_CONFIG: Record<string, TabConfig> = {
   "(home)": {
     label: "Home",
-    icon: (active) => <HomeIcon color={active ? THEME.accent : THEME.ink} />,
+    icon: (active) => (
+      <House
+        size={22}
+        color={active ? ACTIVE_RED : INACTIVE}
+        fill={active ? ACTIVE_RED : INACTIVE}
+        strokeWidth={1.5}
+      />
+    ),
   },
   mix: {
     label: "Mix",
-    icon: (active) => <NoteIcon color={active ? THEME.accent : THEME.ink} />,
+    icon: (active) => (
+      <Music
+        size={22}
+        color={active ? ACTIVE_RED : INACTIVE}
+        fill={active ? ACTIVE_RED : INACTIVE}
+        strokeWidth={1.5}
+      />
+    ),
   },
   profile: {
     label: "Profile",
-    icon: (active) => <PersonIcon color={active ? THEME.accent : THEME.ink} />,
+    icon: (active) => (
+      <User
+        size={22}
+        color={active ? ACTIVE_RED : INACTIVE}
+        fill={active ? ACTIVE_RED : INACTIVE}
+        strokeWidth={1.5}
+      />
+    ),
   },
 };
 
 export function MixTabBar({ state, navigation }: BottomTabBarProps) {
+  const [rowWidth, setRowWidth] = useState(0);
+  const [displayIndex, setDisplayIndex] = useState(state.index);
+  const slideAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(1)).current;
+  const mounted = useRef(false);
+
+  const tabCount = state.routes.length;
+  const contentWidth = rowWidth - ROW_H_PAD * 2;
+  const tabWidth = contentWidth / tabCount;
+
+  // Sync displayIndex when tab changes via press
+  useEffect(() => {
+    setDisplayIndex(state.index);
+    displayIdxRef.current = state.index;
+  }, [state.index]);
+
+  // Refs for stable access inside PanResponder closures
+  const twRef = useRef(tabWidth);
+  const tcRef = useRef(tabCount);
+  const idxRef = useRef(state.index);
+  const routesRef = useRef(state.routes);
+  const navRef = useRef(navigation);
+  const displayIdxRef = useRef(state.index);
+  twRef.current = tabWidth;
+  tcRef.current = tabCount;
+  idxRef.current = state.index;
+  routesRef.current = state.routes;
+  navRef.current = navigation;
+
+  const posFor = (i: number) =>
+    ROW_H_PAD + i * twRef.current + INDICATOR_INSET;
+
+  const dragStart = useRef(0);
+
+  const pan = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponderCapture: (_, gs) =>
+        twRef.current > 0 && Math.abs(gs.dx) > 8,
+      onPanResponderGrant: () => {
+        dragStart.current = idxRef.current;
+        Animated.spring(scaleAnim, {
+          toValue: 1.2,
+          useNativeDriver: true,
+          tension: 300,
+          friction: 12,
+        }).start();
+      },
+      onPanResponderMove: (_, gs) => {
+        const tw = twRef.current;
+        const tc = tcRef.current;
+        const raw = dragStart.current * tw + gs.dx;
+        const clamped = Math.max(0, Math.min((tc - 1) * tw, raw));
+        slideAnim.setValue(ROW_H_PAD + clamped + INDICATOR_INSET);
+
+        const nearest = Math.round(
+          Math.max(0, Math.min(tc - 1, clamped / tw)),
+        );
+        if (nearest !== displayIdxRef.current) {
+          displayIdxRef.current = nearest;
+          setDisplayIndex(nearest);
+        }
+      },
+      onPanResponderRelease: (_, gs) => {
+        const tw = twRef.current;
+        const tc = tcRef.current;
+        const raw = dragStart.current * tw + gs.dx;
+
+        let target: number;
+        if (Math.abs(gs.vx) > FLICK_VX) {
+          target =
+            gs.vx > 0
+              ? Math.min(tc - 1, dragStart.current + 1)
+              : Math.max(0, dragStart.current - 1);
+        } else {
+          target = Math.round(Math.max(0, Math.min(tc - 1, raw / tw)));
+        }
+
+        displayIdxRef.current = target;
+        setDisplayIndex(target);
+
+        Animated.parallel([
+          Animated.spring(slideAnim, {
+            toValue: ROW_H_PAD + target * tw + INDICATOR_INSET,
+            useNativeDriver: true,
+            tension: 180,
+            friction: 15,
+          }),
+          Animated.spring(scaleAnim, {
+            toValue: 1,
+            useNativeDriver: true,
+            tension: 180,
+            friction: 14,
+          }),
+        ]).start();
+
+        if (target !== idxRef.current) {
+          const route = routesRef.current[target];
+          if (route) navRef.current.navigate(route.name as never);
+        }
+      },
+      onPanResponderTerminate: () => {
+        displayIdxRef.current = idxRef.current;
+        setDisplayIndex(idxRef.current);
+
+        Animated.parallel([
+          Animated.spring(slideAnim, {
+            toValue: posFor(idxRef.current),
+            useNativeDriver: true,
+            tension: 300,
+            friction: 25,
+          }),
+          Animated.spring(scaleAnim, {
+            toValue: 1,
+            useNativeDriver: true,
+            tension: 300,
+            friction: 20,
+          }),
+        ]).start();
+      },
+    }),
+  ).current;
+
+  useEffect(() => {
+    if (!rowWidth) return;
+    const toValue = posFor(state.index);
+    if (!mounted.current) {
+      slideAnim.setValue(toValue);
+      mounted.current = true;
+      return;
+    }
+    Animated.spring(slideAnim, {
+      toValue,
+      useNativeDriver: true,
+      tension: 280,
+      friction: 22,
+    }).start();
+  }, [state.index, tabWidth]);
+
   return (
     <View style={styles.wrap}>
-      <BlurView intensity={55} tint="light" style={styles.pill}>
-        <View style={styles.row}>
+      <GlassSurface glassEffectStyle="regular" interactive style={styles.pill}>
+        <View
+          style={styles.row}
+          onLayout={(e) => setRowWidth(e.nativeEvent.layout.width)}
+          {...pan.panHandlers}
+        >
+          {rowWidth > 0 && (
+            <Animated.View
+              style={[
+                styles.indicator,
+                {
+                  width: tabWidth - INDICATOR_INSET * 2,
+                  transform: [
+                    { translateX: slideAnim },
+                    { scaleY: scaleAnim },
+                  ],
+                },
+              ]}
+            >
+              <GlassSurface
+                glassEffectStyle="clear"
+                interactive
+                tintColor="rgba(255,255,255,0.35)"
+                style={styles.indicatorGlass}
+              >
+                <View style={styles.indicatorFill} />
+              </GlassSurface>
+            </Animated.View>
+          )}
+
           {state.routes.map((route, index) => {
             const config = TAB_CONFIG[route.name];
             if (!config) return null;
-            const focused = state.index === index;
+            const focused = displayIndex === index;
             const onPress = () => {
               const event = navigation.emit({
                 type: "tabPress",
                 target: route.key,
                 canPreventDefault: true,
               });
-              if (!focused && !event.defaultPrevented) {
+              if (state.index !== index && !event.defaultPrevented) {
                 navigation.navigate(route.name as never);
               }
             };
@@ -55,14 +257,12 @@ export function MixTabBar({ state, navigation }: BottomTabBarProps) {
                 accessibilityRole="button"
                 accessibilityState={focused ? { selected: true } : {}}
               >
-                <View
-                  style={[styles.itemInner, focused && styles.itemInnerActive]}
-                >
+                <View style={styles.itemInner}>
                   {config.icon(focused)}
                   <Text
                     style={[
                       styles.label,
-                      { color: focused ? THEME.accent : THEME.ink },
+                      { color: focused ? ACTIVE_RED : INACTIVE },
                     ]}
                   >
                     {config.label}
@@ -72,47 +272,48 @@ export function MixTabBar({ state, navigation }: BottomTabBarProps) {
             );
           })}
         </View>
-      </BlurView>
+      </GlassSurface>
     </View>
   );
 }
 
-// ── Icons ────────────────────────────────────────────────────────────
-// Glyph icons to match the preview's style — no extra dependencies.
-
-function HomeIcon({ color }: { color: string }) {
-  return <Text style={[iconStyles.char, { color }]}>⌂</Text>;
-}
-function NoteIcon({ color }: { color: string }) {
-  return <Text style={[iconStyles.char, { color }]}>♫</Text>;
-}
-function PersonIcon({ color }: { color: string }) {
-  return <Text style={[iconStyles.char, { color }]}>☻</Text>;
-}
-
-const iconStyles = StyleSheet.create({
-  char: {
-    fontSize: 22,
-    fontWeight: "700",
-    lineHeight: 24,
-  },
-});
-
 const styles = StyleSheet.create({
-  wrap: { paddingHorizontal: 10 },
+  wrap: {
+    paddingHorizontal: 10,
+    shadowColor: "#000",
+    shadowOpacity: 0.1,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
   pill: {
     borderRadius: 32,
     overflow: "hidden",
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(11,11,11,0.06)",
+    borderColor: "rgba(255,255,255,0.25)",
   },
   row: {
     flexDirection: "row",
-    paddingHorizontal: 6,
-    paddingVertical: 8,
-    backgroundColor: "rgba(246,241,232,0.5)",
+    paddingHorizontal: ROW_H_PAD,
+    paddingVertical: ROW_V_PAD,
   },
-  item: { flex: 1, alignItems: "center" },
+  indicator: {
+    position: "absolute",
+    top: INDICATOR_V_INSET,
+    bottom: INDICATOR_V_INSET,
+    borderRadius: 26,
+    overflow: "hidden",
+  },
+  indicatorGlass: {
+    flex: 1,
+    borderRadius: 26,
+    overflow: "hidden",
+  },
+  indicatorFill: {
+    flex: 1,
+    backgroundColor: "rgba(255,255,255,0.12)",
+  },
+  item: { flex: 1, alignItems: "center", zIndex: 1 },
   itemInner: {
     alignItems: "center",
     justifyContent: "center",
@@ -120,9 +321,6 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     borderRadius: 18,
     gap: 2,
-  },
-  itemInnerActive: {
-    backgroundColor: "rgba(176,42,42,0.10)",
   },
   label: {
     ...THEME.text.tabLabel,

--- a/apps/mobile/src/ui/nav/floatingChromeMetrics.ts
+++ b/apps/mobile/src/ui/nav/floatingChromeMetrics.ts
@@ -1,0 +1,9 @@
+export const FLOATING_CHROME_HORIZONTAL_INSET = 24;
+
+export const NATIVE_TAB_BAR_HEIGHT = 49;
+
+export const NOW_PLAYING_PILL_HEIGHT = 48;
+
+export const FLOATING_CHROME_GAP = 8;
+
+export const FLOATING_CHROME_TOP_PAD = 8;

--- a/apps/mobile/src/ui/playback/NowPlayingPill.tsx
+++ b/apps/mobile/src/ui/playback/NowPlayingPill.tsx
@@ -61,8 +61,8 @@ export function NowPlayingPill({
   return (
     <View style={[styles.wrap, style]}>
       <GlassSurface
-        glassEffectStyle="clear"
-        fallbackBlurIntensity={45}
+        glassEffectStyle="regular"
+        interactive
         style={styles.pill}
       >
         <Pressable
@@ -152,18 +152,18 @@ const styles = StyleSheet.create({
     borderRadius: 30,
     overflow: "hidden",
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(255,255,255,0.35)",
+    borderColor: "rgba(255,255,255,0.25)",
   },
   pillInner: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 14,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
+    gap: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
   },
   art: {
-    width: 40,
-    height: 40,
+    width: 32,
+    height: 32,
     borderRadius: 5,
   },
   meta: { flex: 1, minWidth: 0 },

--- a/apps/mobile/src/ui/playback/NowPlayingPill.tsx
+++ b/apps/mobile/src/ui/playback/NowPlayingPill.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-native";
 import { CoverArt } from "@/ui/CoverArt";
 import { GlassSurface } from "@/ui/glass/GlassSurface";
+import { FLOATING_CHROME_HORIZONTAL_INSET } from "@/ui/nav/floatingChromeMetrics";
 import { THEME } from "@/ui/theme/tokens";
 
 export interface NowPlayingPillProps {
@@ -97,7 +98,7 @@ export function NowPlayingPill({
                 onPress={onPrevious}
               >
                 <Rewind
-                  size={22}
+                  size={20}
                   color={THEME.ink}
                   fill={THEME.ink}
                   strokeWidth={0}
@@ -107,14 +108,14 @@ export function NowPlayingPill({
             <Pressable style={styles.iconBtn} hitSlop={8} onPress={onPlayPause}>
               {isPlaying ? (
                 <Pause
-                  size={22}
+                  size={20}
                   color={THEME.ink}
                   fill={THEME.ink}
                   strokeWidth={0}
                 />
               ) : (
                 <Play
-                  size={22}
+                  size={20}
                   color={THEME.ink}
                   fill={THEME.ink}
                   strokeWidth={0}
@@ -124,7 +125,7 @@ export function NowPlayingPill({
             {onNext ? (
               <Pressable style={styles.iconBtn} hitSlop={8} onPress={onNext}>
                 <FastForward
-                  size={22}
+                  size={20}
                   color={THEME.ink}
                   fill={THEME.ink}
                   strokeWidth={0}
@@ -140,19 +141,18 @@ export function NowPlayingPill({
 
 const styles = StyleSheet.create({
   wrap: {
-    paddingHorizontal: 10,
-    // Lift the pill off the wallpaper. iOS shadow + Android elevation.
+    paddingHorizontal: FLOATING_CHROME_HORIZONTAL_INSET,
     shadowColor: "#000",
-    shadowOpacity: 0.1,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
   },
   pill: {
-    borderRadius: 30,
+    borderRadius: 24,
     overflow: "hidden",
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(255,255,255,0.25)",
+    borderColor: "rgba(255,255,255,0.15)",
   },
   pillInner: {
     flexDirection: "row",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,11 +111,7 @@ importers:
         specifier: ~4.16.0
         version: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg:
-<<<<<<< Updated upstream
         specifier: ~15.12.1
-=======
-        specifier: ^15.12.1
->>>>>>> Stashed changes
         version: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-url-polyfill:
         specifier: ^2.0.0


### PR DESCRIPTION
## What this PR does

Switches the bottom playback/navigation chrome to Expo Router native tabs so iOS gets the system Liquid Glass tab behavior, then aligns the now-playing pill spacing and dimensions to the native tab bar. Also cleans up a persistent `pnpm-lock.yaml` conflict-marker artifact.

## Features implemented

- Replaces the custom React Navigation tab bar in the tabs layout with `expo-router/unstable-native-tabs`
- Keeps the now-playing pill as an overlay above the native iOS tab bar
- Adds shared floating chrome metrics for tab bar height, pill height, side inset, and vertical gap
- Tunes the now-playing pill width/height/internal spacing to align with the native tab bar
- Adds placeholder Activity and Search tab routes required by the native tab layout
- Removes leftover conflict markers from `pnpm-lock.yaml`, keeping the Expo-pinned `react-native-svg` specifier

## Implementation sketch

The app now lets UIKit own the tab bar interaction instead of recreating Apple Music Liquid Glass behavior in JS. The mini-player remains a React Native glass overlay positioned using shared metrics, and screen bottom padding consumes the same metrics to avoid hidden content.

## Closes

Closes #

## Test notes

- `pnpm --filter @mix/mobile type-check`
- Manually compared current and target screenshots for pill/tab width, height, and gap alignment
