### PR TITLE
Warn on conflicting track picks

### DIFF
--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -63,6 +63,7 @@ import { useForceEndRound } from "@/queries/useForceEndRound";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
 import type { SubmissionDraft } from "@/services/submissions";
+import { getLeagueHistoricConflicts } from "@/services/submissions";
 import {
   searchSpotifyTracks,
   getSpotifyTrack,
@@ -119,6 +120,7 @@ type Submission = {
   track_title: string;
   track_artist: string;
   track_artwork_url: string | null;
+  track_album_name: string | null;
   track_source: "spotify" | "soundcloud";
   spotify_track_id: string | null;
   soundcloud_track_url: string | null;
@@ -173,6 +175,8 @@ type DraftSubmission = {
   isEditingTrack: boolean;
   isCheckingLength: boolean;
   trackLimitError: { durationMs: number } | null;
+  conflictBlock: string | null;
+  conflictWarning: { messages: string[]; pendingTrack: PickedTrack } | null;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -246,6 +250,8 @@ function createDraftSubmission(
     isEditingTrack: existing ? false : autoExpand,
     isCheckingLength: false,
     trackLimitError: null,
+    conflictBlock: null,
+    conflictWarning: null,
   };
 }
 
@@ -394,11 +400,15 @@ function TrackRow({
 
 const MAX_TRACK_DURATION_MS = 27 * 60 * 1000;
 
-function TrackLimitBanner({
-  durationMs,
+function HardBlockBanner({
+  label,
+  detail,
+  message,
   onDismiss,
 }: {
-  durationMs: number;
+  label: string;
+  detail?: string;
+  message: string;
   onDismiss: () => void;
 }) {
   const opacity = useRef(new Animated.Value(0)).current;
@@ -427,26 +437,115 @@ function TrackLimitBanner({
   };
 
   return (
-    <Animated.View style={[styles.trackLimitBanner, { opacity }]}>
-      <View style={styles.trackLimitBannerRow}>
-        <View style={styles.trackLimitBannerLeft}>
-          <View style={styles.trackLimitTagRow}>
-            <Text style={styles.trackLimitTag}>TOO LONG</Text>
-            <Text style={styles.trackLimitDuration}>
-              {formatDurationMs(durationMs)}
-            </Text>
+    <Animated.View style={[styles.hardBlockBanner, { opacity }]}>
+      <View style={styles.hardBlockBannerRow}>
+        <View style={styles.hardBlockBannerLeft}>
+          <View style={styles.hardBlockTagRow}>
+            <Text style={styles.hardBlockTag}>{label}</Text>
+            {detail ? (
+              <Text style={styles.hardBlockDetail}>{detail}</Text>
+            ) : null}
           </View>
-          <Text style={styles.trackLimitHint}>
-            max {formatDurationMs(MAX_TRACK_DURATION_MS)} · try a shorter track
-          </Text>
+          <Text style={styles.hardBlockMessage}>{message}</Text>
         </View>
         <TouchableOpacity
           onPress={handleDismiss}
           hitSlop={12}
-          style={styles.trackLimitDismiss}
+          style={styles.hardBlockDismiss}
         >
-          <Text style={styles.trackLimitDismissGlyph}>×</Text>
+          <Text style={styles.hardBlockDismissGlyph}>×</Text>
         </TouchableOpacity>
+      </View>
+    </Animated.View>
+  );
+}
+
+function TrackLimitBanner({
+  durationMs,
+  onDismiss,
+}: {
+  durationMs: number;
+  onDismiss: () => void;
+}) {
+  return (
+    <HardBlockBanner
+      label="TOO LONG"
+      detail={formatDurationMs(durationMs)}
+      message={`max ${formatDurationMs(MAX_TRACK_DURATION_MS)} · try a shorter track`}
+      onDismiss={onDismiss}
+    />
+  );
+}
+
+function SoftWarningBanner({
+  messages,
+  onDismiss,
+  onConfirm,
+}: {
+  messages: string[];
+  onDismiss: () => void;
+  onConfirm: () => void;
+}) {
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 90,
+      useNativeDriver: true,
+    }).start();
+  }, [opacity]);
+
+  const dismiss = () => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 40,
+      useNativeDriver: true,
+    }).start(() => {
+      LayoutAnimation.configureNext({
+        duration: 100,
+        update: { type: "easeInEaseOut" },
+        delete: { type: "easeInEaseOut", property: "opacity" },
+      });
+      onDismiss();
+    });
+  };
+
+  const confirm = () => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 40,
+      useNativeDriver: true,
+    }).start(onConfirm);
+  };
+
+  return (
+    <Animated.View style={[styles.softWarningBanner, { opacity }]}>
+      <View style={styles.softWarningContent}>
+        <View style={styles.softWarningCopy}>
+          <Text style={styles.softWarningTag}>HEADS UP</Text>
+          {messages.map((msg, i) => (
+            <Text key={i} style={styles.softWarningMessage}>
+              {msg}
+            </Text>
+          ))}
+        </View>
+      </View>
+      <View style={styles.softWarningActions}>
+        <Pressable
+          onPress={dismiss}
+          hitSlop={6}
+          style={[styles.softWarningButton, styles.softWarningSecondaryButton]}
+        >
+          <Text style={styles.softWarningSecondaryText}>Cancel</Text>
+        </Pressable>
+        <Pressable
+          onPress={confirm}
+          hitSlop={6}
+          style={[styles.softWarningButton, styles.softWarningPrimaryButton]}
+        >
+          <Text style={styles.softWarningPrimaryText}>Pick anyway</Text>
+        </Pressable>
       </View>
     </Animated.View>
   );
@@ -456,11 +555,13 @@ function SubmissionPhase({
   round,
   userId,
   mySubmissions,
+  allSubmissions,
   onSubmitted,
 }: {
   round: Round;
   userId: string;
   mySubmissions: Submission[];
+  allSubmissions: Submission[];
   onSubmitted: () => void;
 }) {
   const submissionsPerUser = round.seasons?.submissions_per_user ?? 1;
@@ -598,6 +699,8 @@ function SubmissionPhase({
     setSearchState(slotIndex, {
       searchInput,
       trackLimitError: null,
+      conflictBlock: null,
+      conflictWarning: null,
       ...(searchInput.trim()
         ? {}
         : { searchResults: [], isSearching: false }),
@@ -624,10 +727,14 @@ function SubmissionPhase({
         pickedId(draft.track) === incomingId,
     );
     if (duplicateSlot !== -1) {
-      Alert.alert(
-        "Track already selected",
-        `This track is already selected for the other submission.`,
-      );
+      LayoutAnimation.configureNext({
+        duration: 110,
+        create: { type: "easeInEaseOut", property: "opacity" },
+        update: { type: "easeInEaseOut" },
+      });
+      setSearchState(slotIndex, {
+        conflictBlock: "This track is already selected for another slot.",
+      });
       return;
     }
 
@@ -641,6 +748,8 @@ function SubmissionPhase({
               searchResults: [],
               isSearching: false,
               isEditingTrack: false,
+              conflictBlock: null,
+              conflictWarning: null,
             }
           : draft,
       );
@@ -657,28 +766,125 @@ function SubmissionPhase({
   };
 
   const selectTrack = async (slotIndex: number, track: PickedTrack) => {
-    // Spotify ships duration in the search payload, so the check is instant.
+    // Clear any conflict banner from a previous selection attempt in this slot.
+    setSearchState(slotIndex, { conflictBlock: null, conflictWarning: null });
+
+    // Duration check — Spotify has it in the payload; SoundCloud needs probing.
     if (track.source === "spotify") {
       if (track.data.duration_ms > MAX_TRACK_DURATION_MS) {
         rejectTooLong(slotIndex, track.data.duration_ms);
         return;
       }
+    } else {
+      // Guard against double-taps while a probe is already running.
+      if (drafts[slotIndex]?.isCheckingLength) return;
+      setSearchState(slotIndex, { isCheckingLength: true });
+      const durationMs = await probeDuration(track.data.url);
+      setSearchState(slotIndex, { isCheckingLength: false });
+      // Fail open: a null probe (timeout/error) shouldn't block a submission.
+      if (durationMs != null && durationMs > MAX_TRACK_DURATION_MS) {
+        rejectTooLong(slotIndex, durationMs);
+        return;
+      }
+    }
+
+    // Only check against other users' submissions (editing your own slot is fine).
+    const otherSubs = allSubmissions.filter((s) => s.user_id !== userId);
+
+    // AC1: Hard block — exact track already in this round by another user.
+    const roundDuplicate = otherSubs.some((s) => {
+      if (track.source === "spotify") {
+        const isrc = track.data.external_ids?.isrc;
+        return isrc && isrc !== "" && s.track_source === "spotify" && s.track_isrc === isrc;
+      }
+      return s.track_source === "soundcloud" && s.soundcloud_track_url === track.data.url;
+    });
+    if (roundDuplicate) {
+      LayoutAnimation.configureNext({
+        duration: 110,
+        create: { type: "easeInEaseOut", property: "opacity" },
+        update: { type: "easeInEaseOut" },
+      });
+      setSearchState(slotIndex, {
+        conflictBlock: "Someone in this round has already submitted this track.",
+      });
+      return;
+    }
+
+    // AC2–AC4: Collect soft warnings, then surface inline with a "Pick anyway" action.
+    const warnings: string[] = [];
+
+    // AC2a: same artist already in this round.
+    const trackArtist = pickedArtist(track);
+    const hasArtistConflict = otherSubs.some(
+      (s) => s.track_artist.toLowerCase() === trackArtist.toLowerCase(),
+    );
+    if (hasArtistConflict) {
+      warnings.push(`${trackArtist} already has a track in this round.`);
+    }
+
+    // AC2b: same album already in this round (Spotify only). Skip it when
+    // the same-artist warning already covers the likely concern.
+    if (!hasArtistConflict && track.source === "spotify" && track.data.album.name) {
+      const albumName = track.data.album.name;
+      if (otherSubs.some((s) => s.track_album_name?.toLowerCase() === albumName.toLowerCase())) {
+        warnings.push(`Another track from "${albumName}" is already in this round.`);
+      }
+    }
+
+    // AC3 + AC4: historic conflicts — async DB check, fail open.
+    const leagueId = round.seasons?.league_id;
+    if (leagueId) {
+      try {
+        const spotifyIsrc =
+          track.source === "spotify" && track.data.external_ids?.isrc
+            ? track.data.external_ids.isrc
+            : undefined;
+        const soundcloudUrl = track.source === "soundcloud" ? track.data.url : undefined;
+
+        const historic = await getLeagueHistoricConflicts({
+          leagueId,
+          currentRoundId: round.id,
+          userId,
+          spotifyIsrc,
+          soundcloudUrl,
+        });
+
+        // AC4: user has submitted this track before in this league.
+        const myConflicts = historic.filter((c) => c.isMySubmission);
+        if (myConflicts.length > 0) {
+          const places = myConflicts
+            .map((c) => `${c.seasonName}, Round ${c.roundNumber}`)
+            .join(" and ");
+          warnings.push(`You've submitted this track before (${places}).`);
+        }
+
+        // AC3: track already in the league's historic playlist (other submitters).
+        const othersConflicts = historic.filter((c) => !c.isMySubmission);
+        if (othersConflicts.length > 0) {
+          const { seasonName, roundNumber } = othersConflicts[0];
+          warnings.push(
+            `This track is already in the league's playlist (${seasonName}, Round ${roundNumber}).`,
+          );
+        }
+      } catch {
+        // Fail open: don't block track selection if the historic check errors.
+      }
+    }
+
+    if (warnings.length === 0) {
       commitTrack(slotIndex, track);
       return;
     }
 
-    // SoundCloud has no duration in its metadata — probe it via a hidden
-    // widget. Guard against double-taps while a probe is already running.
-    if (drafts[slotIndex]?.isCheckingLength) return;
-    setSearchState(slotIndex, { isCheckingLength: true });
-    const durationMs = await probeDuration(track.data.url);
-    setSearchState(slotIndex, { isCheckingLength: false });
-    // Fail open: a null probe (timeout/error) shouldn't block a submission.
-    if (durationMs != null && durationMs > MAX_TRACK_DURATION_MS) {
-      rejectTooLong(slotIndex, durationMs);
-      return;
-    }
-    commitTrack(slotIndex, track);
+    LayoutAnimation.configureNext({
+      duration: 110,
+      create: { type: "easeInEaseOut", property: "opacity" },
+      update: { type: "easeInEaseOut" },
+    });
+    setSearchState(slotIndex, {
+      conflictWarning: { messages: warnings, pendingTrack: track },
+    });
   };
 
   // EDIT button on a filled slot reuses this: clears the track AND flips
@@ -693,6 +899,8 @@ function SubmissionPhase({
       searchResults: [],
       isSearching: false,
       trackLimitError: null,
+      conflictBlock: null,
+      conflictWarning: null,
     });
   };
 
@@ -899,6 +1107,22 @@ function SubmissionPhase({
                 <TrackLimitBanner
                   durationMs={draft.trackLimitError.durationMs}
                   onDismiss={() => setSearchState(index, { trackLimitError: null })}
+                />
+              )}
+
+              {draft.conflictBlock && (
+                <HardBlockBanner
+                  label="ALREADY IN ROUND"
+                  message={draft.conflictBlock}
+                  onDismiss={() => setSearchState(index, { conflictBlock: null })}
+                />
+              )}
+
+              {draft.conflictWarning && (
+                <SoftWarningBanner
+                  messages={draft.conflictWarning.messages}
+                  onDismiss={() => setSearchState(index, { conflictWarning: null })}
+                  onConfirm={() => commitTrack(index, draft.conflictWarning!.pendingTrack)}
                 />
               )}
 
@@ -2705,6 +2929,7 @@ export function RoundScreen({
                 round={round}
                 userId={userId}
                 mySubmissions={mySubmissions}
+                allSubmissions={submissions}
                 onSubmitted={() => router.back()}
               />
             </KeyboardScroll>
@@ -2860,6 +3085,7 @@ export function RoundScreen({
                 round={round}
                 userId={userId}
                 mySubmissions={mySubmissions}
+                allSubmissions={submissions}
                 onSubmitted={() => router.back()}
               />
             ))}
@@ -3618,8 +3844,8 @@ const styles = StyleSheet.create({
     color: THEME.muted,
   },
 
-  // ─── Track duration limit rejection banner ────────────────────────────────
-  trackLimitBanner: {
+  // ─── Inline track selection feedback ──────────────────────────────────────
+  hardBlockBanner: {
     backgroundColor: THEME.ink,
     borderRadius: 12,
     borderWidth: 1,
@@ -3627,44 +3853,103 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingVertical: 12,
   },
-  trackLimitBannerRow: {
+  hardBlockBannerRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
   },
-  trackLimitBannerLeft: {
+  hardBlockBannerLeft: {
     flex: 1,
     gap: 4,
   },
-  trackLimitTagRow: {
+  hardBlockTagRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
   },
-  trackLimitTag: {
+  hardBlockTag: {
     fontFamily: THEME.fonts.monoBold,
     fontSize: 9,
     letterSpacing: 1.8,
     color: "#C4FF3D",
   },
-  trackLimitDuration: {
+  hardBlockDetail: {
     fontFamily: THEME.fonts.monoBold,
     fontSize: 12,
     color: "#FFD9EC",
   },
-  trackLimitHint: {
+  hardBlockMessage: {
     fontFamily: THEME.fonts.sansMedium,
     fontSize: 11,
     color: "rgba(255,217,236,0.55)",
   },
-  trackLimitDismiss: {
+  hardBlockDismiss: {
     paddingLeft: 12,
   },
-  trackLimitDismissGlyph: {
+  hardBlockDismissGlyph: {
     fontFamily: THEME.fonts.sansBold,
     fontSize: 18,
     color: "rgba(255,217,236,0.5)",
     lineHeight: 20,
+  },
+  softWarningBanner: {
+    backgroundColor: "rgba(255,255,255,0.58)",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: THEME.rule,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    gap: 12,
+  },
+  softWarningContent: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+  softWarningCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  softWarningTag: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 9,
+    letterSpacing: 1.8,
+    color: THEME.muted,
+  },
+  softWarningMessage: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 12,
+    lineHeight: 16,
+    color: THEME.ink,
+  },
+  softWarningActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+  },
+  softWarningButton: {
+    minHeight: 38,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  softWarningSecondaryButton: {
+    backgroundColor: "rgba(255,255,255,0.45)",
+    borderWidth: 1,
+    borderColor: THEME.rule,
+  },
+  softWarningPrimaryButton: {
+    backgroundColor: THEME.ink,
+  },
+  softWarningSecondaryText: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 13,
+    color: THEME.ink,
+  },
+  softWarningPrimaryText: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 13,
+    color: "#FFD9EC",
   },
   // Shown while an ephemeral widget probes a SoundCloud track's duration.
   checkingLengthRow: {

--- a/apps/mobile/src/services/submissions.ts
+++ b/apps/mobile/src/services/submissions.ts
@@ -106,6 +106,86 @@ export async function submitRoundEntries(
   }
 }
 
+// ─── Historic conflict detection ─────────────────────────────────────────────
+
+export type HistoricTrackConflict = {
+  roundId: string;
+  roundNumber: number;
+  roundPrompt: string;
+  seasonName: string;
+  isMySubmission: boolean;
+};
+
+// Returns every prior submission in the league that matches the given track
+// identifier, excluding the current round. Used to surface soft warnings at
+// track-selection time (AC3: league history; AC4: user's own history).
+// Queries in two steps to avoid deep nested join filter limitations.
+// Fails open: callers catch and skip rather than blocking submission.
+export async function getLeagueHistoricConflicts(args: {
+  leagueId: string;
+  currentRoundId: string;
+  userId: string;
+  spotifyIsrc?: string;
+  soundcloudUrl?: string;
+}): Promise<HistoricTrackConflict[]> {
+  const { leagueId, currentRoundId, userId, spotifyIsrc, soundcloudUrl } = args;
+  if (!spotifyIsrc && !soundcloudUrl) return [];
+
+  type RoundMeta = {
+    id: string;
+    round_number: number;
+    prompt: string;
+    seasons: { name: string } | null;
+  };
+
+  const { data: roundsRaw, error: roundsErr } = await supabase
+    .from("rounds")
+    .select("id, round_number, prompt, seasons!inner(name)")
+    .eq("seasons.league_id", leagueId)
+    .neq("id", currentRoundId);
+  if (roundsErr) throw postgresToMixError(roundsErr);
+
+  const rounds = (roundsRaw ?? []) as unknown as RoundMeta[];
+  if (rounds.length === 0) return [];
+
+  const roundIds = rounds.map((r) => r.id);
+  const roundById = new Map<string, RoundMeta>(rounds.map((r) => [r.id, r]));
+
+  type SubRow = { user_id: string; round_id: string };
+  let subRows: SubRow[];
+
+  if (spotifyIsrc) {
+    const { data, error } = await supabase
+      .from("submissions")
+      .select("user_id, round_id")
+      .in("round_id", roundIds)
+      .eq("track_source", "spotify")
+      .eq("track_isrc", spotifyIsrc);
+    if (error) throw postgresToMixError(error);
+    subRows = (data ?? []) as SubRow[];
+  } else {
+    const { data, error } = await supabase
+      .from("submissions")
+      .select("user_id, round_id")
+      .in("round_id", roundIds)
+      .eq("track_source", "soundcloud")
+      .eq("soundcloud_track_url", soundcloudUrl!);
+    if (error) throw postgresToMixError(error);
+    subRows = (data ?? []) as SubRow[];
+  }
+
+  return subRows.map((s) => {
+    const round = roundById.get(s.round_id);
+    return {
+      roundId: s.round_id,
+      roundNumber: round?.round_number ?? 0,
+      roundPrompt: round?.prompt ?? "",
+      seasonName: round?.seasons?.name ?? "",
+      isMySubmission: s.user_id === userId,
+    };
+  });
+}
+
 // ─── Batched submission counts ────────────────────────────────────────────────
 // Returns a map of roundId → submission count for the requested rounds.
 // One Supabase query: PostgREST doesn't support server-side GROUP BY, so we

--- a/apps/mobile/src/services/votes.ts
+++ b/apps/mobile/src/services/votes.ts
@@ -10,6 +10,7 @@ export type VotingSubmission = {
   track_title: string;
   track_artist: string;
   track_artwork_url: string | null;
+  track_album_name: string | null;
   track_source: "spotify" | "soundcloud";
   spotify_track_id: string | null;
   soundcloud_track_url: string | null;
@@ -34,7 +35,7 @@ export async function getRoundSubmissions(
   const { data, error } = await supabase
     .from("submissions")
     .select(
-      "id, user_id, track_title, track_artist, track_artwork_url, track_source, spotify_track_id, soundcloud_track_url, track_isrc, comment, playlist_position",
+      "id, user_id, track_title, track_artist, track_artwork_url, track_album_name, track_source, spotify_track_id, soundcloud_track_url, track_isrc, comment, playlist_position",
     )
     .eq("round_id", roundId)
     .order("playlist_position", { ascending: true, nullsFirst: false });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,11 +111,7 @@ importers:
         specifier: ~4.16.0
         version: 4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-svg:
-<<<<<<< Updated upstream
         specifier: ~15.12.1
-=======
-        specifier: ^15.12.1
->>>>>>> Stashed changes
         version: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-url-polyfill:
         specifier: ^2.0.0


### PR DESCRIPTION
## Summary
- hard-block exact duplicate track picks within the active round and within local submission slots
- show softer inline warnings for same-artist, same-album, historic league, and prior user submissions with a Pick anyway action
- reuse the hard-block banner treatment for too-long tracks and exact duplicates; lighten the soft warning UI
- clean up leftover conflict markers in pnpm-lock.yaml

Closes #22

## Verification
- pnpm --filter @mix/mobile type-check
- git diff --check

## Notes
- pnpm --filter @mix/mobile lint is currently blocked because ESLint 9 expects eslint.config.js, which is not present in this repo.