### PR TITLE
Fix top gap on round pages

### DIFF
--- a/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
+++ b/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
@@ -22,7 +22,6 @@ import {
   View,
   useWindowDimensions,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useFocusEffect } from "expo-router";
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
@@ -189,9 +188,9 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
   if (!round) {
     return (
       <Wallpaper halftone={false}>
-        <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
+        <View style={{ flex: 1 }}>
           <ActivityIndicator color={THEME.ink} style={{ marginTop: 80 }} />
-        </SafeAreaView>
+        </View>
       </Wallpaper>
     );
   }
@@ -207,95 +206,93 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
 
   return (
     <Wallpaper halftone={false}>
-      <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={onRefresh}
-              tintColor={THEME.ink}
-            />
-          }
-        >
-          {/* Hero — same image+video+fade as the voting screen so the iOS
-              zoom transition lands seamlessly when navigating from results. */}
-          <View>
-            <RoundHero imageKey={ROUND_HERO_IMAGE_KEY} heroHeight={heroHeight} />
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={THEME.ink}
+          />
+        }
+      >
+        {/* Hero — same image+video+fade as the voting screen so the iOS
+            zoom transition lands seamlessly when navigating from results. */}
+        <View>
+          <RoundHero imageKey={ROUND_HERO_IMAGE_KEY} heroHeight={heroHeight} />
 
-            <View style={styles.titleOverlay} pointerEvents="none">
-              <View style={styles.titleRow}>
-                <Text style={styles.titleText} numberOfLines={3}>
-                  {round.prompt}
-                </Text>
-                <ChromeText
-                  glyph="★"
-                  size={22}
-                  style={styles.titleStar}
-                />
-              </View>
-              <View style={styles.metaRow}>
-                {pillLabel ? (
-                  <View style={styles.metaPill}>
-                    <Text style={styles.metaPillText} numberOfLines={1}>
-                      {pillLabel}
-                    </Text>
-                  </View>
-                ) : null}
-                <Text style={styles.metaTail} numberOfLines={1}>
-                  {pillLabel ? " · " : ""}
-                  {metaTail}
-                </Text>
-              </View>
+          <View style={styles.titleOverlay} pointerEvents="none">
+            <View style={styles.titleRow}>
+              <Text style={styles.titleText} numberOfLines={3}>
+                {round.prompt}
+              </Text>
+              <ChromeText
+                glyph="★"
+                size={22}
+                style={styles.titleStar}
+              />
+            </View>
+            <View style={styles.metaRow}>
+              {pillLabel ? (
+                <View style={styles.metaPill}>
+                  <Text style={styles.metaPillText} numberOfLines={1}>
+                    {pillLabel}
+                  </Text>
+                </View>
+              ) : null}
+              <Text style={styles.metaTail} numberOfLines={1}>
+                {pillLabel ? " · " : ""}
+                {metaTail}
+              </Text>
             </View>
           </View>
+        </View>
 
-          {/* Buttons */}
-          <View style={styles.buttonsRow}>
-            <ChromeButton onPress={onPlay} style={{ flex: 1 }}>
-              <View style={styles.playTriangle} />
-              <Text style={styles.btnLabelDark}>Play</Text>
-            </ChromeButton>
-            <Pressable
-              style={[styles.btnInner, styles.btnDarkBg]}
-              onPress={onAddToSpotify}
-            >
-              <Text style={styles.btnGlyphLight}>+</Text>
-              <Text style={styles.btnLabelLight}>Add to Spotify</Text>
-            </Pressable>
-          </View>
+        {/* Buttons */}
+        <View style={styles.buttonsRow}>
+          <ChromeButton onPress={onPlay} style={{ flex: 1 }}>
+            <View style={styles.playTriangle} />
+            <Text style={styles.btnLabelDark}>Play</Text>
+          </ChromeButton>
+          <Pressable
+            style={[styles.btnInner, styles.btnDarkBg]}
+            onPress={onAddToSpotify}
+          >
+            <Text style={styles.btnGlyphLight}>+</Text>
+            <Text style={styles.btnLabelLight}>Add to Spotify</Text>
+          </Pressable>
+        </View>
 
-          {/* Playlist rows */}
-          <View style={styles.playlistBody}>
-            {submissions.map((sub, idx) => {
-              // ID-based current-track match — works even when the currently
-              // playing track is from a different playlist than this round.
-              const playingTrackId =
-                playback.currentIndex !== null
-                  ? playback.playlist[playback.currentIndex]?.id
-                  : null;
-              const isCurrentTrack = playingTrackId === sub.id;
-              return (
-                <PlaylistTrackRow
-                  key={sub.id}
-                  submission={sub}
-                  points={pointsBySub[sub.id] ?? 0}
-                  isWinner={winningSubId === sub.id}
-                  voters={votersData[sub.id] ?? []}
-                  isLast={idx === submissions.length - 1}
-                  isCurrentTrack={isCurrentTrack}
-                  isPlaying={isCurrentTrack && playback.isPlaying}
-                  onPress={() => {
-                    if (orderedPlaylist.length === 0) return;
-                    playback.playPlaylist(orderedPlaylist, idx);
-                  }}
-                />
-              );
-            })}
-          </View>
-        </ScrollView>
-      </SafeAreaView>
+        {/* Playlist rows */}
+        <View style={styles.playlistBody}>
+          {submissions.map((sub, idx) => {
+            // ID-based current-track match — works even when the currently
+            // playing track is from a different playlist than this round.
+            const playingTrackId =
+              playback.currentIndex !== null
+                ? playback.playlist[playback.currentIndex]?.id
+                : null;
+            const isCurrentTrack = playingTrackId === sub.id;
+            return (
+              <PlaylistTrackRow
+                key={sub.id}
+                submission={sub}
+                points={pointsBySub[sub.id] ?? 0}
+                isWinner={winningSubId === sub.id}
+                voters={votersData[sub.id] ?? []}
+                isLast={idx === submissions.length - 1}
+                isCurrentTrack={isCurrentTrack}
+                isPlaying={isCurrentTrack && playback.isPlaying}
+                onPress={() => {
+                  if (orderedPlaylist.length === 0) return;
+                  playback.playPlaylist(orderedPlaylist, idx);
+                }}
+              />
+            );
+          })}
+        </View>
+      </ScrollView>
     </Wallpaper>
   );
 }

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -38,7 +38,7 @@ if (
   UIManager.setLayoutAnimationEnabledExperimental(true);
 }
 import { Stack, useRouter, useFocusEffect } from "expo-router";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Wallpaper } from "@/ui/Wallpaper";
 import { KeyboardScroll } from "@/components/KeyboardScroll";
 import { ChromeText } from "@/ui/ChromeText";
@@ -2700,6 +2700,7 @@ export function RoundScreen({
   const { supabaseUserId } = useSession();
   const userId = supabaseUserId;
   const bottomInset = useTabBarBottomInset();
+  const { top: topInset } = useSafeAreaInsets();
 
   const { data: round, isLoading: roundLoading, refetch: refetchRound } =
     useRound(roundId);
@@ -2906,34 +2907,36 @@ export function RoundScreen({
           }}
         />
         <Wallpaper>
-          <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
-            <KeyboardScroll
-              contentContainerStyle={[
-                styles.submitScroll,
-                { paddingBottom: bottomInset + 36 },
-              ]}
-              // Gap kept between the keyboard and the focused field. Bump this
-              // if a field still feels too close to the keyboard.
-              extraScrollHeight={48}
-              enableOnAndroid
-              refreshControl={
-                <RefreshControl
-                  refreshing={refreshing}
-                  onRefresh={onRefresh}
-                  tintColor={THEME.ink}
-                />
-              }
-            >
-              <SubmissionsHero round={round} countdown={countdown} />
-              <SubmissionPhase
-                round={round}
-                userId={userId}
-                mySubmissions={mySubmissions}
-                allSubmissions={submissions}
-                onSubmitted={() => router.back()}
+          <KeyboardScroll
+            style={{ flex: 1 }}
+            contentContainerStyle={[
+              styles.submitScroll,
+              {
+                paddingTop: topInset + 12,
+                paddingBottom: bottomInset + 36,
+              },
+            ]}
+            // Gap kept between the keyboard and the focused field. Bump this
+            // if a field still feels too close to the keyboard.
+            extraScrollHeight={48}
+            enableOnAndroid
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={onRefresh}
+                tintColor={THEME.ink}
               />
-            </KeyboardScroll>
-          </SafeAreaView>
+            }
+          >
+            <SubmissionsHero round={round} countdown={countdown} />
+            <SubmissionPhase
+              round={round}
+              userId={userId}
+              mySubmissions={mySubmissions}
+              allSubmissions={submissions}
+              onSubmitted={() => router.back()}
+            />
+          </KeyboardScroll>
         </Wallpaper>
       </>
     );
@@ -2943,11 +2946,13 @@ export function RoundScreen({
   if (phase === "results") {
     return (
       <Wallpaper halftone={false}>
-        <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
         <ScrollView
           ref={scrollViewRef}
           style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
+          contentContainerStyle={{
+            paddingTop: topInset,
+            paddingBottom: bottomInset + 24,
+          }}
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
@@ -2987,7 +2992,6 @@ export function RoundScreen({
             onBack={() => router.back()}
           />
         </ScrollView>
-        </SafeAreaView>
       </Wallpaper>
     );
   }


### PR DESCRIPTION
## Summary
- let the playlist hero render from the top of the screen instead of below the safe-area inset
- remove top SafeAreaView wrappers from submissions/results and preserve spacing with scroll content padding
- keep transparent native headers while avoiding the visible top boundary on pushed round pages

## Verification
- pnpm --filter @mix/mobile type-check

## Notes
- pnpm --filter @mix/mobile lint is currently blocked because ESLint 9 cannot find an eslint.config.js file in the app config.