### PR TITLE
Use native zoom for Now Playing

### DIFF
--- a/apps/mobile/modules/native-zoom/ios/NativeZoomModule.swift
+++ b/apps/mobile/modules/native-zoom/ios/NativeZoomModule.swift
@@ -14,6 +14,12 @@ public class NativeZoomModule: Module {
         // UIView previously registered by a <ZoomSource id={...}>.
         Function("armZoomTransition") { (sourceId: String) -> Void in
             NativeZoomRegistry.shared.armedSourceId = sourceId
+            NativeZoomRegistry.shared.armedAlignment = nil
+        }
+
+        Function("armZoomTransitionWithAlignment") { (sourceId: String, alignment: String) -> Void in
+            NativeZoomRegistry.shared.armedSourceId = sourceId
+            NativeZoomRegistry.shared.armedAlignment = alignment
         }
 
         View(ZoomSourceView.self) {

--- a/apps/mobile/modules/native-zoom/ios/NativeZoomRegistry.swift
+++ b/apps/mobile/modules/native-zoom/ios/NativeZoomRegistry.swift
@@ -12,6 +12,7 @@ final class NativeZoomRegistry {
 
     // The id to apply to the *next* pushed UIViewController. Cleared after use.
     var armedSourceId: String?
+    var armedAlignment: String?
 
     func register(_ view: UIView, forId id: String) {
         sources[id] = WeakView(view: view)

--- a/apps/mobile/modules/native-zoom/ios/NativeZoomSwizzle.swift
+++ b/apps/mobile/modules/native-zoom/ios/NativeZoomSwizzle.swift
@@ -1,10 +1,9 @@
 import UIKit
 import ObjectiveC
 
-// Swizzles UINavigationController.pushViewController(_:animated:) so we can
-// set preferredTransition = .zoom on the incoming VC when a transition is
-// "armed" from JS. Scoped to run at most once. Non-armed pushes are
-// unaffected — the swizzle forwards straight to the original implementation.
+// Swizzles push/present so we can set preferredTransition = .zoom on the
+// incoming VC when a transition is "armed" from JS. Scoped to run at most once.
+// Non-armed transitions forward straight to the original UIKit implementation.
 
 enum NativeZoomSwizzle {
     // static let with a side-effecting initializer is Swift's idiom for
@@ -22,6 +21,18 @@ enum NativeZoomSwizzle {
         if let original = original, let swizzled = swizzled {
             method_exchangeImplementations(original, swizzled)
         }
+
+        let originalPresent = class_getInstanceMethod(
+            UIViewController.self,
+            #selector(UIViewController.present(_:animated:completion:))
+        )
+        let swizzledPresent = class_getInstanceMethod(
+            UIViewController.self,
+            #selector(UIViewController.nativeZoom_present(_:animated:completion:))
+        )
+        if let originalPresent = originalPresent, let swizzledPresent = swizzledPresent {
+            method_exchangeImplementations(originalPresent, swizzledPresent)
+        }
     }()
 }
 
@@ -30,19 +41,63 @@ extension UINavigationController {
         _ viewController: UIViewController,
         animated: Bool
     ) {
-        if let sourceId = NativeZoomRegistry.shared.armedSourceId {
-            NativeZoomRegistry.shared.armedSourceId = nil
-
-            if #available(iOS 18.0, *),
-               let sourceView = NativeZoomRegistry.shared.sourceView(forId: sourceId) {
-                viewController.preferredTransition = .zoom(sourceViewProvider: { _ in
-                    sourceView
-                })
-            }
-        }
+        NativeZoomSwizzle.applyArmedZoom(to: viewController)
 
         // After swizzle, calling nativeZoom_pushViewController invokes the
         // original UIKit implementation.
         self.nativeZoom_pushViewController(viewController, animated: animated)
+    }
+}
+
+extension UIViewController {
+    @objc func nativeZoom_present(
+        _ viewControllerToPresent: UIViewController,
+        animated flag: Bool,
+        completion: (() -> Void)? = nil
+    ) {
+        NativeZoomSwizzle.applyArmedZoom(to: viewControllerToPresent)
+
+        // After swizzle, calling nativeZoom_present invokes the original UIKit implementation.
+        self.nativeZoom_present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+}
+
+private extension NativeZoomSwizzle {
+    @available(iOS 18.0, *)
+    static func makeZoomTransition(sourceView: UIView, alignment: String?) -> UIViewController.Transition {
+        let options = zoomOptions(for: alignment)
+        return .zoom(options: options, sourceViewProvider: { _ in
+            sourceView
+        })
+    }
+
+    static func applyArmedZoom(to viewController: UIViewController) {
+        guard let sourceId = NativeZoomRegistry.shared.armedSourceId else { return }
+        NativeZoomRegistry.shared.armedSourceId = nil
+        let alignment = NativeZoomRegistry.shared.armedAlignment
+        NativeZoomRegistry.shared.armedAlignment = nil
+
+        if #available(iOS 18.0, *),
+           let sourceView = NativeZoomRegistry.shared.sourceView(forId: sourceId) {
+            viewController.preferredTransition = makeZoomTransition(sourceView: sourceView, alignment: alignment)
+        }
+    }
+
+    @available(iOS 18.0, *)
+    static func zoomOptions(for alignment: String?) -> UIViewController.Transition.ZoomOptions? {
+        guard alignment == "nowPlayingArt" else { return nil }
+
+        let options = UIViewController.Transition.ZoomOptions()
+        options.alignmentRectProvider = { context in
+            let view = context.zoomedViewController.view
+            let width = view?.bounds.width ?? UIScreen.main.bounds.width
+            let topInset = view?.safeAreaInsets.top ?? 0
+            let artSize = max(0, width - 40)
+
+            // Mirrors NowPlayingContent's top bar + content/art margins so the
+            // pill artwork lands on the large album-art frame during native zoom.
+            return CGRect(x: 20, y: topInset + 37, width: artSize, height: artSize)
+        }
+        return options
     }
 }

--- a/apps/mobile/modules/native-zoom/package.json
+++ b/apps/mobile/modules/native-zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-zoom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Local Expo Module that wraps iOS 18's UIViewController.preferredTransition = .zoom for React Native.",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/apps/mobile/modules/native-zoom/src/index.ts
+++ b/apps/mobile/modules/native-zoom/src/index.ts
@@ -6,6 +6,7 @@ import type { ViewProps } from "react-native";
 // error, so swap to an if-ios wrapper if you start supporting Android).
 const NativeZoom: {
   armZoomTransition: (sourceId: string) => void;
+  armZoomTransitionWithAlignment: (sourceId: string, alignment: string) => void;
 } = requireNativeModule("NativeZoom");
 
 // Arm the NEXT UINavigationController.pushViewController call to use iOS 18's
@@ -14,6 +15,10 @@ const NativeZoom: {
 // back to the standard push animation.
 export function armZoomTransition(sourceId: string): void {
   NativeZoom.armZoomTransition(sourceId);
+}
+
+export function armZoomTransitionToNowPlayingArt(sourceId: string): void {
+  NativeZoom.armZoomTransitionWithAlignment(sourceId, "nowPlayingArt");
 }
 
 export type ZoomSourceProps = ViewProps & {

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -112,6 +112,13 @@ export default function RootLayout() {
                   >
                     <Stack.Screen name="(auth)/index" />
                     <Stack.Screen name="(tabs)" />
+                    <Stack.Screen
+                      name="now-playing"
+                      options={{
+                        animation: "default",
+                        gestureEnabled: true,
+                      }}
+                    />
                     <Stack.Screen name="auth/callback" />
                     <Stack.Screen name="join/index" />
                     {/* TEMP: preview routes for UI experiments. Delete when done. */}

--- a/apps/mobile/src/app/now-playing.tsx
+++ b/apps/mobile/src/app/now-playing.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'expo-router';
+import { StyleSheet, View } from 'react-native';
+import { NowPlayingContent } from '@/components/NowPlayingModal';
+
+export default function NowPlayingRoute() {
+  const router = useRouter();
+
+  return (
+    <View style={styles.root}>
+      <NowPlayingContent onClose={() => router.back()} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#EDD7FF',
+  },
+});

--- a/apps/mobile/src/components/NowPlayingModal.tsx
+++ b/apps/mobile/src/components/NowPlayingModal.tsx
@@ -19,6 +19,7 @@ import {
   Image,
   LayoutAnimation,
   PanResponder,
+  Pressable,
   ScrollView,
   StyleSheet,
   Text,
@@ -956,9 +957,9 @@ const voteStyles = StyleSheet.create({
   },
 });
 
-// ─── Modal ────────────────────────────────────────────────────────────────────
+// ─── Now Playing surface ──────────────────────────────────────────────────────
 
-export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClose: () => void }) {
+export function NowPlayingContent({ onClose }: { onClose?: () => void }) {
   const insets = useSafeAreaInsets();
   const {
     currentIndex, playlist,
@@ -1018,6 +1019,86 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
   }, [phase, currentSubId, results, voters]);
 
   return (
+    <Wallpaper halftone={false}>
+      {/* Grab handle — signals dismiss. On the routed screen, tapping it pops
+          the native zoom transition back into the pill. */}
+      <Pressable
+        style={[modalStyles.topBar, { paddingTop: insets.top + 10 }]}
+        onPress={onClose}
+        disabled={!onClose}
+        hitSlop={10}
+      >
+        <View style={modalStyles.handle} />
+      </Pressable>
+
+      <View style={[modalStyles.content, { paddingBottom: insets.bottom + 18 }]}>
+        <View style={modalStyles.artBlock}>
+          <AlbumArtSwiper />
+        </View>
+
+        {/* Everything under the art. The title is pinned just below the
+            (large) art footprint so it never shifts when the art scales;
+            the controls + scrubber float vertically centered in the space
+            between the title and the bottom panel. */}
+        <View style={modalStyles.belowArt}>
+          <View style={modalStyles.titleRow}>
+            <View style={modalStyles.titleCol}>
+              <Text style={modalStyles.title} numberOfLines={1}>
+                {title || (hasTrack ? 'Loading…' : 'Nothing playing')}
+              </Text>
+              {artist ? (
+                <Text style={modalStyles.artist} numberOfLines={1}>
+                  {artist}
+                </Text>
+              ) : null}
+            </View>
+            <TouchableOpacity
+              style={modalStyles.moreBtn}
+              hitSlop={8}
+              // TODO: overflow menu (add to playlist, share, view round…).
+              onPress={() => {}}
+            >
+              <MoreHorizontal size={20} color={THEME.ink} strokeWidth={2.5} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={modalStyles.controlsRegion}>
+            {/* Transport sits above the scrubber per the requested layout. */}
+            <Transport
+              isPlaying={isPlaying}
+              onPlayPause={isPlaying ? pause : resume}
+              onPrevious={previous}
+              onNext={next}
+              hasTrack={hasTrack}
+              canPrevious={canPrevious}
+              hasNext={hasNext}
+            />
+
+            <SeekBar positionMs={positionMs} durationMs={durationMs} onSeek={seek} />
+          </View>
+
+          {completed ? (
+            <CompletedRoundPanel
+              rank={completed.rank}
+              points={completed.points}
+              isVoid={completed.isVoid}
+              comments={completed.comments}
+            />
+          ) : null}
+
+          {showVoting ? (
+            <VotingPanel draft={draft} subId={currentSubId!} />
+          ) : null}
+        </View>
+      </View>
+    </Wallpaper>
+  );
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClose: () => void }) {
+  return (
     <SwipeSheet
       visible={visible}
       onRequestClose={onClose}
@@ -1032,75 +1113,7 @@ export function NowPlayingModal({ visible, onClose }: { visible: boolean; onClos
       // render our own grab handle inside the Wallpaper below.
       showHandle={false}
     >
-      {() => (
-        <Wallpaper halftone={false}>
-          {/* Grab handle — signals swipe-to-dismiss. */}
-          <View style={[modalStyles.topBar, { paddingTop: insets.top + 10 }]}>
-            <View style={modalStyles.handle} />
-          </View>
-
-          <View style={[modalStyles.content, { paddingBottom: insets.bottom + 18 }]}>
-            <View style={modalStyles.artBlock}>
-              <AlbumArtSwiper />
-            </View>
-
-            {/* Everything under the art. The title is pinned just below the
-                (large) art footprint so it never shifts when the art scales;
-                the controls + scrubber float vertically centered in the space
-                between the title and the bottom panel. */}
-            <View style={modalStyles.belowArt}>
-              <View style={modalStyles.titleRow}>
-                <View style={modalStyles.titleCol}>
-                  <Text style={modalStyles.title} numberOfLines={1}>
-                    {title || (hasTrack ? 'Loading…' : 'Nothing playing')}
-                  </Text>
-                  {artist ? (
-                    <Text style={modalStyles.artist} numberOfLines={1}>
-                      {artist}
-                    </Text>
-                  ) : null}
-                </View>
-                <TouchableOpacity
-                  style={modalStyles.moreBtn}
-                  hitSlop={8}
-                  // TODO: overflow menu (add to playlist, share, view round…).
-                  onPress={() => {}}
-                >
-                  <MoreHorizontal size={20} color={THEME.ink} strokeWidth={2.5} />
-                </TouchableOpacity>
-              </View>
-
-              <View style={modalStyles.controlsRegion}>
-                {/* Transport sits above the scrubber per the requested layout. */}
-                <Transport
-                  isPlaying={isPlaying}
-                  onPlayPause={isPlaying ? pause : resume}
-                  onPrevious={previous}
-                  onNext={next}
-                  hasTrack={hasTrack}
-                  canPrevious={canPrevious}
-                  hasNext={hasNext}
-                />
-
-                <SeekBar positionMs={positionMs} durationMs={durationMs} onSeek={seek} />
-              </View>
-
-              {completed ? (
-                <CompletedRoundPanel
-                  rank={completed.rank}
-                  points={completed.points}
-                  isVoid={completed.isVoid}
-                  comments={completed.comments}
-                />
-              ) : null}
-
-              {showVoting ? (
-                <VotingPanel draft={draft} subId={currentSubId!} />
-              ) : null}
-            </View>
-          </View>
-        </Wallpaper>
-      )}
+      <NowPlayingContent onClose={onClose} />
     </SwipeSheet>
   );
 }

--- a/apps/mobile/src/components/NowPlayingPillConnected.tsx
+++ b/apps/mobile/src/components/NowPlayingPillConnected.tsx
@@ -1,13 +1,20 @@
 // Wires the pure NowPlayingPill (presentation) to the PlaybackContext.
-// Hidden when there is no current track. Tapping the pill opens the full
-// Now Playing modal extracted into NowPlayingModal.tsx.
+// Hidden when there is no current track. Tapping the pill opens the routed
+// Now Playing screen using iOS's native zoom transition.
 
-import { useState } from 'react';
+import { useCallback, useRef } from 'react';
+import { Animated } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { armZoomTransitionToNowPlayingArt } from 'native-zoom';
 import { usePlayback } from '@/playback/PlaybackContext';
 import { NowPlayingPill } from '@/ui/playback/NowPlayingPill';
-import { NowPlayingModal } from '@/components/NowPlayingModal';
+
+const NOW_PLAYING_ZOOM_SOURCE_ID = 'now-playing-pill';
 
 export function NowPlayingPillConnected() {
+  const router = useRouter();
+  const scale = useRef(new Animated.Value(1)).current;
+  const bounceOnReturn = useRef(false);
   const {
     currentIndex,
     playlist,
@@ -20,15 +27,33 @@ export function NowPlayingPillConnected() {
     next,
     previous,
   } = usePlayback();
-  const [expanded, setExpanded] = useState(false);
+
+  const hasNext = currentIndex !== null && currentIndex < playlist.length - 1;
+  const hasPrevious = currentIndex !== null && currentIndex > 0;
+  const openNowPlaying = useCallback(() => {
+    bounceOnReturn.current = true;
+    armZoomTransitionToNowPlayingArt(NOW_PLAYING_ZOOM_SOURCE_ID);
+    router.push('/now-playing' as never);
+  }, [router]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!bounceOnReturn.current) return;
+      bounceOnReturn.current = false;
+      scale.setValue(0.98);
+      Animated.spring(scale, {
+        toValue: 1,
+        speed: 22,
+        bounciness: 12,
+        useNativeDriver: true,
+      }).start();
+    }, [scale]),
+  );
 
   if (currentIndex === null) return null;
 
-  const hasNext = currentIndex < playlist.length - 1;
-  const hasPrevious = currentIndex > 0;
-
   return (
-    <>
+    <Animated.View style={{ transform: [{ scale }] }}>
       <NowPlayingPill
         title={title || 'Loading…'}
         artist={artist || undefined}
@@ -37,9 +62,9 @@ export function NowPlayingPillConnected() {
         onPlayPause={isPlaying ? pause : resume}
         onNext={hasNext ? next : undefined}
         onPrevious={hasPrevious ? previous : undefined}
-        onPress={() => setExpanded(true)}
+        onPress={openNowPlaying}
+        zoomSourceId={NOW_PLAYING_ZOOM_SOURCE_ID}
       />
-      <NowPlayingModal visible={expanded} onClose={() => setExpanded(false)} />
-    </>
+    </Animated.View>
   );
 }

--- a/apps/mobile/src/ui/playback/NowPlayingPill.tsx
+++ b/apps/mobile/src/ui/playback/NowPlayingPill.tsx
@@ -8,6 +8,7 @@
 
 import { Image } from "expo-image";
 import { FastForward, Pause, Play, Rewind } from "lucide-react-native";
+import { ZoomSource } from "native-zoom";
 import {
   Pressable,
   StyleSheet,
@@ -39,6 +40,7 @@ export interface NowPlayingPillProps {
   /** When omitted, the previous button is hidden entirely (first track). */
   onPrevious?: () => void;
   onPress?: () => void;
+  zoomSourceId?: string;
   style?: StyleProp<ViewStyle>;
 }
 
@@ -53,11 +55,22 @@ export function NowPlayingPill({
   onNext,
   onPrevious,
   onPress,
+  zoomSourceId,
   style,
 }: NowPlayingPillProps) {
   // Hue prop accepts strings (legacy from preview) and numbers — normalize.
   const numericHue =
     typeof hue === "number" ? hue : hue != null ? Number(hue) : 200;
+
+  const art = artworkUrl ? (
+    <Image source={{ uri: artworkUrl }} style={styles.artFill} />
+  ) : (
+    <CoverArt
+      hue={Number.isFinite(numericHue) ? numericHue : 200}
+      dual={dual}
+      style={styles.artFill}
+    />
+  );
 
   return (
     <View style={[styles.wrap, style]}>
@@ -71,14 +84,12 @@ export function NowPlayingPill({
           onPress={onPress}
           disabled={!onPress}
         >
-          {artworkUrl ? (
-            <Image source={{ uri: artworkUrl }} style={styles.art} />
+          {zoomSourceId ? (
+            <ZoomSource zoomSourceId={zoomSourceId} style={styles.art}>
+              {art}
+            </ZoomSource>
           ) : (
-            <CoverArt
-              hue={Number.isFinite(numericHue) ? numericHue : 200}
-              dual={dual}
-              style={styles.art}
-            />
+            <View style={styles.art}>{art}</View>
           )}
           <View style={styles.meta}>
             <Text style={styles.title} numberOfLines={1}>
@@ -165,7 +176,9 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 5,
+    overflow: "hidden",
   },
+  artFill: { width: "100%", height: "100%" },
   meta: { flex: 1, minWidth: 0 },
   title: { ...THEME.text.nowPlayingTitle },
   artist: { ...THEME.text.nowPlayingArtist, marginTop: 1 },


### PR DESCRIPTION
## Summary
- Opens Now Playing as a routed screen instead of the floating pill owning a JS modal
- Registers the pill artwork as the native zoom source and arms an iOS zoom transition before navigation
- Extends the local native-zoom module with an optional alignment mode for the Now Playing artwork rect
- Reuses the existing Now Playing content in both the routed screen and the legacy SwipeSheet modal path

## Notes
- This keeps the implementation simple and native-backed, but UIKit's zoom transition animates the destination view-controller snapshot rather than producing Apple Music's exact shared album-art morph.
- Native changes require a dev-app rebuild after pulling/applying this branch.

## Test plan
- pnpm --filter @mix/mobile type-check
- Manual iOS simulator/device smoke test of opening and closing Now Playing from the pill