### PR TITLE
Add deadline extension voting MVP

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Stack, useRouter, useSegments } from "expo-router";
+import "@/lib/disableFontScaling";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   useFonts as useFraunces,

--- a/apps/mobile/src/lib/disableFontScaling.ts
+++ b/apps/mobile/src/lib/disableFontScaling.ts
@@ -1,0 +1,63 @@
+import { Text, TextInput } from "react-native";
+
+// React 19 no longer reliably applies `defaultProps` to function components.
+// Patch the JSX runtime instead so every <Text>/<TextInput> element receives
+// the prop, including components imported before app render.
+type JsxRuntime = {
+  jsx?: (type: unknown, props: unknown, key?: unknown) => unknown;
+  jsxs?: (type: unknown, props: unknown, key?: unknown) => unknown;
+  jsxDEV?: (
+    type: unknown,
+    props: unknown,
+    key?: unknown,
+    isStaticChildren?: unknown,
+    source?: unknown,
+    self?: unknown,
+  ) => unknown;
+  __mixDisableFontScalingPatched?: boolean;
+};
+
+type Props = Record<string, unknown> | null | undefined;
+
+function patchProps(type: unknown, props: Props): Props {
+  if (type !== Text && type !== TextInput) return props;
+  return { ...(props ?? {}), allowFontScaling: false };
+}
+
+function patchRuntime(runtime: JsxRuntime) {
+  if (runtime.__mixDisableFontScalingPatched) return;
+
+  const originalJsx = runtime.jsx;
+  if (originalJsx) {
+    runtime.jsx = (type, props, key) => originalJsx(type, patchProps(type, props as Props), key);
+  }
+
+  const originalJsxs = runtime.jsxs;
+  if (originalJsxs) {
+    runtime.jsxs = (type, props, key) => originalJsxs(type, patchProps(type, props as Props), key);
+  }
+
+  const originalJsxDEV = runtime.jsxDEV;
+  if (originalJsxDEV) {
+    runtime.jsxDEV = (type, props, key, isStaticChildren, source, self) =>
+      originalJsxDEV(
+        type,
+        patchProps(type, props as Props),
+        key,
+        isStaticChildren,
+        source,
+        self,
+      );
+  }
+
+  runtime.__mixDisableFontScalingPatched = true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+patchRuntime(require("react/jsx-runtime") as JsxRuntime);
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  patchRuntime(require("react/jsx-dev-runtime") as JsxRuntime);
+} catch {
+  // Production bundles may not include the dev runtime.
+}

--- a/apps/mobile/src/lib/utils/dueCopy.ts
+++ b/apps/mobile/src/lib/utils/dueCopy.ts
@@ -1,0 +1,52 @@
+function isSameLocalDate(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function formatDateLabel(due: Date, now: Date): string {
+  if (isSameLocalDate(due, now)) return "today";
+  if (isSameLocalDate(due, addDays(now, 1))) return "tomorrow";
+  return due.toLocaleDateString("en-US", {
+    month: "2-digit",
+    day: "2-digit",
+    year: "2-digit",
+  });
+}
+
+function formatTime(due: Date): string {
+  return due.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatRemaining(diffMs: number): string | null {
+  if (diffMs <= 0 || diffMs >= 24 * 60 * 60 * 1000) return null;
+
+  if (diffMs < 60 * 60 * 1000) {
+    const minutes = Math.floor(diffMs / 60_000);
+    return `${minutes} ${minutes === 1 ? "min" : "mins"} left!`;
+  }
+
+  const hours = Math.floor(diffMs / (60 * 60 * 1000));
+  return `~${hours} ${hours === 1 ? "hour" : "hours"} left!`;
+}
+
+export function formatVotesDueCopy(
+  deadlineIso: string,
+  now: Date = new Date(),
+): string {
+  const due = new Date(deadlineIso);
+  const base = `Votes due ${formatDateLabel(due, now)} at ${formatTime(due)}`;
+  const remaining = formatRemaining(due.getTime() - now.getTime());
+  return remaining ? `${base} · ${remaining}` : base;
+}

--- a/apps/mobile/src/queries/invalidation.ts
+++ b/apps/mobile/src/queries/invalidation.ts
@@ -42,6 +42,27 @@ export const invalidations = {
       qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
     }
   },
+  deadlineExtension: (
+    qc: QueryClient,
+    ctx: { roundId: string; deadlineType: string },
+  ) => {
+    return Promise.all([
+      qc.invalidateQueries({ queryKey: queryKeys.round(ctx.roundId) }),
+      qc.invalidateQueries({
+        predicate: (q) => {
+          const key = q.queryKey as readonly unknown[];
+          return (
+            key[0] === "round" &&
+            key[1] === ctx.roundId &&
+            key[2] === "deadlineExtension" &&
+            key[3] === ctx.deadlineType
+          );
+        },
+      }),
+      qc.invalidateQueries({ queryKey: ["league"] }),
+      qc.invalidateQueries({ queryKey: ["season"] }),
+    ]);
+  },
   createRound: (qc: QueryClient, ctx: { seasonId: string }) => {
     qc.invalidateQueries({ queryKey: queryKeys.season(ctx.seasonId) });
   },

--- a/apps/mobile/src/queries/keys.ts
+++ b/apps/mobile/src/queries/keys.ts
@@ -14,6 +14,11 @@ export const queryKeys = {
     ["season", seasonId, "prevRound", roundNumber] as const,
   roundResults: (roundId: string) => ["round", roundId, "results"] as const,
   roundVoters: (roundId: string) => ["round", roundId, "voters"] as const,
+  deadlineExtensionState: (
+    roundId: string,
+    deadlineType: string,
+    userId: string,
+  ) => ["round", roundId, "deadlineExtension", deadlineType, userId] as const,
   submissionCounts: (roundIds: string[]) =>
     ["submissionCounts", ...roundIds.slice().sort()] as const,
   // Resolves a submission back to its round (a submission's round never

--- a/apps/mobile/src/queries/useCancelDeadlineExtensionRequest.ts
+++ b/apps/mobile/src/queries/useCancelDeadlineExtensionRequest.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { cancelDeadlineExtensionRequest } from "@/services/deadlineExtensions";
+import { invalidations } from "./invalidation";
+
+export function useCancelDeadlineExtensionRequest() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: cancelDeadlineExtensionRequest,
+    onSuccess: async (_data, variables) => {
+      await invalidations.deadlineExtension(qc, {
+        roundId: variables.roundId,
+        deadlineType: variables.deadlineType,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useCommissionerExtendDeadline.ts
+++ b/apps/mobile/src/queries/useCommissionerExtendDeadline.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { commissionerExtendDeadline } from "@/services/deadlineExtensions";
+import { invalidations } from "./invalidation";
+
+export function useCommissionerExtendDeadline() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: commissionerExtendDeadline,
+    onSuccess: async (_data, variables) => {
+      await invalidations.deadlineExtension(qc, {
+        roundId: variables.roundId,
+        deadlineType: variables.deadlineType,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/queries/useDeadlineExtensionState.ts
+++ b/apps/mobile/src/queries/useDeadlineExtensionState.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getDeadlineExtensionState,
+  type DeadlineExtensionType,
+} from "@/services/deadlineExtensions";
+import { queryKeys } from "./keys";
+
+export function useDeadlineExtensionState(
+  roundId: string | undefined,
+  deadlineType: DeadlineExtensionType | undefined,
+  userId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.deadlineExtensionState(
+      roundId ?? "",
+      deadlineType ?? "submission",
+      userId ?? "",
+    ),
+    queryFn: () => getDeadlineExtensionState(roundId!, deadlineType!, userId!),
+    enabled: !!roundId && !!deadlineType && !!userId,
+  });
+}

--- a/apps/mobile/src/queries/useRequestDeadlineExtension.ts
+++ b/apps/mobile/src/queries/useRequestDeadlineExtension.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { requestDeadlineExtension } from "@/services/deadlineExtensions";
+import { invalidations } from "./invalidation";
+
+export function useRequestDeadlineExtension() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: requestDeadlineExtension,
+    onSuccess: async (_data, variables) => {
+      await invalidations.deadlineExtension(qc, {
+        roundId: variables.roundId,
+        deadlineType: variables.deadlineType,
+      });
+    },
+  });
+}

--- a/apps/mobile/src/screens/create-season/CreateSeasonFlow.tsx
+++ b/apps/mobile/src/screens/create-season/CreateSeasonFlow.tsx
@@ -20,6 +20,8 @@ type SeasonForm = {
   submissionsPerUser: number;
   pointsPerRound: number;
   maxPointsPerTrack: number;
+  extensionThresholdPercent: number;
+  extensionDurationHours: number;
   startDate: Date;
   submissionDays: number;
   votingDays: number;
@@ -170,6 +172,39 @@ function StepSeason({ form, onChange }: { form: SeasonForm; onChange: (f: Season
       </View>
 
       <View style={styles.divider} />
+      <Text style={styles.groupLabel}>EXTENSION REQUESTS</Text>
+
+      <Field label="Approval Threshold" hint="Percent of participants needed to extend an active deadline">
+        <View style={styles.stepperRow}>
+          <Stepper
+            value={form.extensionThresholdPercent}
+            onChange={(v) => onChange({ ...form, extensionThresholdPercent: v })}
+            min={1}
+            max={100}
+          />
+          <Text style={styles.stepperUnit}>%</Text>
+        </View>
+      </Field>
+
+      <Field label="Extension Length" hint="Applied each time enough participants request an extension">
+        <View style={styles.stepperRow}>
+          <Stepper
+            value={form.extensionDurationHours}
+            onChange={(v) => onChange({ ...form, extensionDurationHours: v })}
+            min={1}
+            max={168}
+          />
+          <Text style={styles.stepperUnit}>{form.extensionDurationHours === 1 ? 'hour' : 'hours'}</Text>
+        </View>
+      </Field>
+
+      <View style={styles.cadenceSummary}>
+        <Text style={styles.cadenceSummaryText}>
+          Extension requests can pass more than once, but never past the next deadline boundary.
+        </Text>
+      </View>
+
+      <View style={styles.divider} />
       <Text style={styles.groupLabel}>SCORING</Text>
 
       <Field label="Submissions Per Round" hint="How many tracks each player submits per round">
@@ -310,6 +345,8 @@ const defaultSeason: SeasonForm = {
   submissionsPerUser: 2,
   pointsPerRound: 10,
   maxPointsPerTrack: 5,
+  extensionThresholdPercent: 33,
+  extensionDurationHours: 24,
   startDate: defaultStart,
   submissionDays: 5,
   votingDays: 3,
@@ -372,6 +409,9 @@ export function CreateSeasonFlow() {
         submissionsPerUser: season.submissionsPerUser,
         defaultPointsPerRound: season.pointsPerRound,
         defaultMaxPointsPerTrack: season.maxPointsPerTrack,
+        deadlineExtensionThresholdPercent: season.extensionThresholdPercent,
+        deadlineExtensionDurationMinutes: season.extensionDurationHours * 60,
+        deadlineExtensionMaxPerPhase: null,
         rounds: rounds.map((r) => ({
           prompt: r.prompt,
           description: r.description.trim(),

--- a/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
+++ b/apps/mobile/src/screens/playlist/PlaylistScreen.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo, useState } from "react";
 import {
+  ActionSheetIOS,
   ActivityIndicator,
   Alert,
   Image,
@@ -27,8 +28,10 @@ import { useRouter, useFocusEffect } from "expo-router";
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
+  Clock,
   MessageCircle,
   MessageCircleMore,
+  Plus,
 } from "lucide-react-native";
 
 import { useRound } from "@/queries/useRound";
@@ -41,11 +44,12 @@ import { normalizeSpotifyTrackUri } from "@/lib/spotifyTrackUri";
 import { useTabBarBottomInset } from "@/ui/hooks/useTabBarBottomInset";
 import { THEME } from "@/ui/theme";
 import { Wallpaper } from "@/ui/Wallpaper";
+import { BouncyPressable } from "@/ui/BouncyPressable";
 import { ChromeText } from "@/ui/ChromeText";
 import { ChromeBorder } from "@/ui/ChromeBorder";
-import { ChromeButton } from "@/ui/ChromeButton";
 import { RoundHero, ROUND_HERO_IMAGE_KEY } from "@/ui/cards/RoundHero";
 import { PlayingIndicator } from "@/ui/playback/PlayingIndicator";
+import { formatVotesDueCopy } from "@/lib/utils/dueCopy";
 
 if (
   Platform.OS === "android" &&
@@ -164,10 +168,18 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
   };
 
   const onAddToSpotify = () => {
-    Alert.alert(
-      "Add to Spotify",
-      "Coming soon — this will save the round playlist to your Spotify account.",
-    );
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: "Add",
+          options: ["Cancel", "Add to Spotify"],
+          cancelButtonIndex: 0,
+        },
+        () => {},
+      );
+      return;
+    }
+    Alert.alert("Add", "Add to Spotify");
   };
 
   // Pull-to-refresh — same mechanism as the home tab.
@@ -196,14 +208,7 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
     );
   }
 
-  const pickNum = String(round.round_number).padStart(2, "0");
-  const pillLabel = [
-    `R${pickNum}`,
-    round.seasons?.name ? round.seasons.name.toUpperCase() : "",
-  ]
-    .filter(Boolean)
-    .join(" · ");
-  const metaTail = `${submissions.length} TRACKS · FINAL`;
+  const dueCopy = formatVotesDueCopy(round.voting_deadline_at);
 
   return (
     <Wallpaper halftone={false}>
@@ -222,49 +227,49 @@ export function PlaylistScreen({ roundId }: { roundId: string }) {
           {/* Hero — same image+video+fade as the voting screen so the iOS
               zoom transition lands seamlessly when navigating from results. */}
           <View>
-            <RoundHero imageKey={ROUND_HERO_IMAGE_KEY} heroHeight={heroHeight} />
+            <RoundHero
+              imageKey={ROUND_HERO_IMAGE_KEY}
+              heroHeight={heroHeight}
+            />
 
             <View style={styles.titleOverlay} pointerEvents="none">
               <View style={styles.titleRow}>
                 <Text style={styles.titleText} numberOfLines={3}>
                   {round.prompt}
                 </Text>
-                <ChromeText
-                  glyph="★"
-                  size={22}
-                  style={styles.titleStar}
-                />
+                <ChromeText glyph="★" size={22} style={styles.titleStar} />
               </View>
-              <View style={styles.metaRow}>
-                {pillLabel ? (
-                  <View style={styles.metaPill}>
-                    <Text style={styles.metaPillText} numberOfLines={1}>
-                      {pillLabel}
-                    </Text>
-                  </View>
-                ) : null}
-                <Text style={styles.metaTail} numberOfLines={1}>
-                  {pillLabel ? " · " : ""}
-                  {metaTail}
+              {round.description ? (
+                <Text style={styles.heroDescription} numberOfLines={3}>
+                  {round.description}
                 </Text>
-              </View>
+              ) : null}
             </View>
           </View>
 
           {/* Buttons */}
-          <View style={styles.buttonsRow}>
-            <ChromeButton onPress={onPlay} style={{ flex: 1 }}>
+          <View style={styles.controlsRow}>
+            <BouncyPressable
+              style={[styles.circleControl, styles.circleControlMuted]}
+              disabled
+            >
+              <Clock size={17} color={THEME.ink} strokeWidth={2.6} />
+            </BouncyPressable>
+            <BouncyPressable style={styles.playControl} onPress={onPlay}>
               <View style={styles.playTriangle} />
-              <Text style={styles.btnLabelDark}>Play</Text>
-            </ChromeButton>
-            <Pressable
-              style={[styles.btnInner, styles.btnDarkBg]}
+              <Text style={styles.playControlText}>Play</Text>
+            </BouncyPressable>
+            <BouncyPressable
+              style={styles.circleControl}
               onPress={onAddToSpotify}
             >
-              <Text style={styles.btnGlyphLight}>+</Text>
-              <Text style={styles.btnLabelLight}>Add to Spotify</Text>
-            </Pressable>
+              <Plus size={17} color={THEME.ink} strokeWidth={2.6} />
+            </BouncyPressable>
           </View>
+
+          <Text style={styles.dueLine} numberOfLines={2}>
+            {dueCopy}
+          </Text>
 
           {/* Playlist rows */}
           <View style={styles.playlistBody}>
@@ -332,9 +337,7 @@ function PlaylistTrackRow({
   // Visible voters in the accordion: comment authors only (this screen is
   // about reading reactions, not about who voted how). Voter ordering kept
   // as-is from the RPC.
-  const commenters = voters.filter(
-    (v) => (v.comment ?? "").trim().length > 0,
-  );
+  const commenters = voters.filter((v) => (v.comment ?? "").trim().length > 0);
   const hasComments = commenters.length > 0;
 
   const toggle = () => {
@@ -350,14 +353,13 @@ function PlaylistTrackRow({
 
   return (
     <View>
-      <TouchableOpacity activeOpacity={0.7} onPress={onPress} style={styles.row}>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        onPress={onPress}
+        style={styles.row}
+      >
         {submission.track_artwork_url ? (
-          <ChromeBorder
-            radius={8}
-            thickness={1}
-            clip
-            style={styles.rowArt}
-          >
+          <ChromeBorder radius={8} thickness={1} clip style={styles.rowArt}>
             <Image
               source={{ uri: submission.track_artwork_url }}
               style={{ width: "100%", height: "100%" }}
@@ -375,11 +377,7 @@ function PlaylistTrackRow({
               {submission.track_title}
             </Text>
             {isWinner ? (
-              <ChromeText
-                glyph="★"
-                size={14}
-                style={{ marginLeft: 4 }}
-              />
+              <ChromeText glyph="★" size={14} style={{ marginLeft: 4 }} />
             ) : null}
           </View>
           <Text style={styles.rowArtist} numberOfLines={1}>
@@ -510,13 +508,59 @@ const styles = StyleSheet.create({
     color: THEME.ink,
   },
 
-  // Buttons row
-  buttonsRow: {
-    flexDirection: "row",
-    gap: 10,
-    paddingHorizontal: 22,
-    marginTop: 8,
+  dueLine: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 13,
+    lineHeight: 18,
+    color: THEME.ink,
+    textAlign: "center",
+    paddingHorizontal: 28,
     marginBottom: 18,
+  },
+  heroDescription: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 15,
+    lineHeight: 20,
+    color: "rgba(26,8,20,0.52)",
+    textAlign: "center",
+    marginTop: -1,
+  },
+
+  // Controls row
+  controlsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    paddingHorizontal: 34,
+    marginTop: 12,
+    marginBottom: 14,
+  },
+  circleControl: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.72)",
+  },
+  circleControlMuted: {
+    opacity: 0.45,
+  },
+  playControl: {
+    minWidth: 155,
+    height: 46,
+    borderRadius: 23,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 7,
+    backgroundColor: "#050405",
+  },
+  playControlText: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 13,
+    color: "#fff",
   },
   btnInner: {
     flex: 1,
@@ -543,12 +587,12 @@ const styles = StyleSheet.create({
   playTriangle: {
     width: 0,
     height: 0,
-    borderTopWidth: 7,
-    borderBottomWidth: 7,
-    borderLeftWidth: 10,
+    borderTopWidth: 6,
+    borderBottomWidth: 6,
+    borderLeftWidth: 9,
     borderTopColor: "transparent",
     borderBottomColor: "transparent",
-    borderLeftColor: THEME.ink,
+    borderLeftColor: "#fff",
     marginLeft: 2,
   },
   btnGlyphLight: {
@@ -556,7 +600,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: "#e8d5ff",
   },
-
   // Playlist rows
   playlistBody: {
     paddingHorizontal: 18,

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -10,6 +10,7 @@ import {
   TouchableOpacity,
   Pressable,
   ActivityIndicator,
+  ActionSheetIOS,
   TextInput,
   Alert,
   Image,
@@ -25,8 +26,10 @@ import { LinearGradient } from "expo-linear-gradient";
 import {
   ChevronUp,
   ChevronDown,
+  Clock,
   MessageCircle,
   MessageCircleMore,
+  Plus,
 } from "lucide-react-native";
 import { imageForKey, toneForKey } from "@/ui/theme/images";
 import { videoForKey } from "@/ui/theme/videos";
@@ -41,9 +44,9 @@ import { Stack, useRouter, useFocusEffect } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Wallpaper } from "@/ui/Wallpaper";
 import { KeyboardScroll } from "@/components/KeyboardScroll";
+import { BouncyPressable } from "@/ui/BouncyPressable";
 import { ChromeText } from "@/ui/ChromeText";
 import { ChromeBorder } from "@/ui/ChromeBorder";
-import { ChromeButton } from "@/ui/ChromeButton";
 import { HaloText } from "@/ui/HaloText";
 import { FittedChromeTitle } from "@/ui/FittedChromeTitle";
 import { useSession } from "@/context/SessionContext";
@@ -60,8 +63,12 @@ import { useMyRole } from "@/queries/useMyRole";
 import { useRoundResults } from "@/queries/useRoundResults";
 import { useRoundVoters } from "@/queries/useRoundVoters";
 import { useForceEndRound } from "@/queries/useForceEndRound";
+import { useDeadlineExtensionState } from "@/queries/useDeadlineExtensionState";
+import { useRequestDeadlineExtension } from "@/queries/useRequestDeadlineExtension";
+import { useCancelDeadlineExtensionRequest } from "@/queries/useCancelDeadlineExtensionRequest";
 import { MixError } from "@/services/errors";
 import type { VoteInput, VoteCommentInput } from "@/services/votes";
+import type { DeadlineExtensionType } from "@/services/deadlineExtensions";
 import type { SubmissionDraft } from "@/services/submissions";
 import {
   searchSpotifyTracks,
@@ -81,6 +88,7 @@ import { useTabBarBottomInset } from "@/ui/hooks/useTabBarBottomInset";
 import { PODIUM_STOPS } from "@/ui/metalStops";
 import { derivePhase, formatPhaseCountdown } from "@/lib/utils/phase";
 import { roundCoverKey } from "@/lib/utils/coverKey";
+import { formatVotesDueCopy } from "@/lib/utils/dueCopy";
 import { usePlayback, type PlaylistTrack } from "@/playback/PlaybackContext";
 import { useSoundCloudDurationProbe } from "@/playback/useSoundCloudDurationProbe";
 import { normalizeSpotifyTrackUri } from "@/lib/spotifyTrackUri";
@@ -194,7 +202,10 @@ function formatDurationMs(ms: number): string {
 }
 
 function submissionToTrack(submission: Submission): PickedTrack {
-  if (submission.track_source === "soundcloud" && submission.soundcloud_track_url) {
+  if (
+    submission.track_source === "soundcloud" &&
+    submission.soundcloud_track_url
+  ) {
     return {
       source: "soundcloud",
       data: {
@@ -334,6 +345,211 @@ function ThemedButton({
         </Text>
       )}
     </TouchableOpacity>
+  );
+}
+
+function DeadlineExtensionCard({
+  roundId,
+  userId,
+  deadlineType,
+}: {
+  roundId: string;
+  userId: string;
+  deadlineType: DeadlineExtensionType;
+}) {
+  const { data: state, isLoading } = useDeadlineExtensionState(
+    roundId,
+    deadlineType,
+    userId,
+  );
+  const requestMutation = useRequestDeadlineExtension();
+  const cancelMutation = useCancelDeadlineExtensionRequest();
+  const pending = requestMutation.isPending || cancelMutation.isPending;
+  const requestPending = requestMutation.isPending || cancelMutation.isPending;
+
+  if (isLoading || !state || !state.enabled) {
+    return null;
+  }
+
+  const unavailable = !state.extensionAllowed || state.extensionLimitReached;
+  const shouldShow = state.closesWithinExtensionWindow;
+  if (!shouldShow) return null;
+
+  const canRequest = !unavailable;
+  const requestsRemaining = Math.max(
+    0,
+    state.thresholdCount - state.requestedCount,
+  );
+  const requestedByline =
+    requestsRemaining === 1
+      ? "1 more request auto-extends the deadline"
+      : `${requestsRemaining} more requests auto-extend the deadline`;
+
+  const runRequest = async () => {
+    try {
+      if (state.userRequested) {
+        await cancelMutation.mutateAsync({ roundId, deadlineType, userId });
+      } else {
+        await requestMutation.mutateAsync({ roundId, deadlineType, userId });
+      }
+    } catch (err) {
+      Alert.alert(
+        "Extension request failed",
+        err instanceof MixError ? err.message : "Unknown error",
+      );
+    }
+  };
+
+  return (
+    <View style={styles.extensionCard}>
+      <View style={styles.extensionHeaderRow}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.extensionPrompt}>
+            {unavailable
+              ? "No further extensions possible"
+              : state.userRequested
+                ? "Extension requested"
+                : "Need more time?"}
+          </Text>
+          {state.userRequested && !unavailable ? (
+            <Text style={styles.extensionByline}>{requestedByline}</Text>
+          ) : null}
+        </View>
+
+        <View style={styles.extensionActions}>
+          <TouchableOpacity
+            style={[
+              styles.extensionButton,
+              state.userRequested &&
+                !unavailable &&
+                styles.extensionButtonSecondary,
+              (!canRequest || pending) && styles.extensionButtonDisabled,
+            ]}
+            onPress={runRequest}
+            disabled={!canRequest || pending}
+          >
+            {requestPending ? (
+              <ActivityIndicator
+                size="small"
+                color={state.userRequested && !unavailable ? THEME.ink : "#fff"}
+              />
+            ) : (
+              <Text
+                style={[
+                  styles.extensionButtonText,
+                  state.userRequested &&
+                    !unavailable &&
+                    styles.extensionButtonSecondaryText,
+                ]}
+              >
+                {state.userRequested && !unavailable
+                  ? "Cancel request"
+                  : "Request extension"}
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {state.lastOutcome === "blocked" ? (
+        <Text style={styles.extensionWarning}>
+          Last extension was blocked by the season timeline.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function DeadlineExtensionControlButton({
+  roundId,
+  userId,
+  deadlineType,
+}: {
+  roundId: string;
+  userId: string;
+  deadlineType: DeadlineExtensionType;
+}) {
+  const { data: state, isLoading } = useDeadlineExtensionState(
+    roundId,
+    deadlineType,
+    userId,
+  );
+  const requestMutation = useRequestDeadlineExtension();
+  const cancelMutation = useCancelDeadlineExtensionRequest();
+  const pending = requestMutation.isPending || cancelMutation.isPending;
+
+  const unavailable =
+    !state ||
+    !state.enabled ||
+    !state.closesWithinExtensionWindow ||
+    !state.extensionAllowed ||
+    state.extensionLimitReached;
+
+  const runRequest = async () => {
+    if (!state || unavailable) return;
+    try {
+      if (state.userRequested) {
+        await cancelMutation.mutateAsync({ roundId, deadlineType, userId });
+      } else {
+        await requestMutation.mutateAsync({ roundId, deadlineType, userId });
+      }
+    } catch (err) {
+      Alert.alert(
+        "Extension request failed",
+        err instanceof MixError ? err.message : "Unknown error",
+      );
+    }
+  };
+
+  const onPress = () => {
+    if (!state || unavailable) return;
+    const actionLabel = state.userRequested
+      ? "Cancel request"
+      : "Request extension";
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: "Extension request",
+          options: ["Cancel", actionLabel],
+          cancelButtonIndex: 0,
+        },
+        (buttonIndex) => {
+          if (buttonIndex === 1) void runRequest();
+        },
+      );
+      return;
+    }
+
+    Alert.alert("Extension request", actionLabel, [
+      { text: "Cancel", style: "cancel" },
+      { text: actionLabel, onPress: () => void runRequest() },
+    ]);
+  };
+
+  return (
+    <BouncyPressable
+      style={[
+        styles.voteCircleControl,
+        (isLoading || unavailable || pending) && styles.voteCircleControlMuted,
+        state?.userRequested && !unavailable && styles.voteCircleControlActive,
+      ]}
+      onPress={onPress}
+      disabled={isLoading || unavailable || pending}
+      accessibilityLabel={
+        state?.userRequested ? "Cancel extension request" : "Request extension"
+      }
+    >
+      {pending ? (
+        <ActivityIndicator size="small" color={THEME.ink} />
+      ) : (
+        <Clock
+          size={20}
+          color={state?.userRequested && !unavailable ? "#fff" : THEME.ink}
+          strokeWidth={2.6}
+        />
+      )}
+    </BouncyPressable>
   );
 }
 
@@ -483,7 +699,9 @@ function SubmissionPhase({
   }, [mySubmissions, submissionsPerUser]);
   const searchDebounceKeys = useMemo(
     () =>
-      drafts.map((draft) => `${draft.isEditingTrack}:${draft.searchInput}`).join("|"),
+      drafts
+        .map((draft) => `${draft.isEditingTrack}:${draft.searchInput}`)
+        .join("|"),
     [drafts],
   );
   const searchableDrafts = useMemo(
@@ -598,9 +816,7 @@ function SubmissionPhase({
     setSearchState(slotIndex, {
       searchInput,
       trackLimitError: null,
-      ...(searchInput.trim()
-        ? {}
-        : { searchResults: [], isSearching: false }),
+      ...(searchInput.trim() ? {} : { searchResults: [], isSearching: false }),
     });
   };
 
@@ -769,13 +985,11 @@ function SubmissionPhase({
   // next slot if there's one beyond the visible set. Slots further out stay
   // hidden until the user advances.
   const lastVisibleIdx = drafts.reduce(
-    (acc, draft, i) =>
-      draft.track || draft.isEditingTrack ? i : acc,
+    (acc, draft, i) => (draft.track || draft.isEditingTrack ? i : acc),
     -1,
   );
   const peekIdx =
-    lastVisibleIdx + 1 < drafts.length &&
-    !drafts[lastVisibleIdx + 1]?.track
+    lastVisibleIdx + 1 < drafts.length && !drafts[lastVisibleIdx + 1]?.track
       ? lastVisibleIdx + 1
       : null;
 
@@ -898,7 +1112,9 @@ function SubmissionPhase({
               {draft.trackLimitError && (
                 <TrackLimitBanner
                   durationMs={draft.trackLimitError.durationMs}
-                  onDismiss={() => setSearchState(index, { trackLimitError: null })}
+                  onDismiss={() =>
+                    setSearchState(index, { trackLimitError: null })
+                  }
                 />
               )}
 
@@ -917,7 +1133,12 @@ function SubmissionPhase({
                   onPress={() => selectTrack(index, track)}
                 >
                   {pickedArtwork(track) ? (
-                    <ChromeBorder radius={8} thickness={1} clip style={styles.searchResultArt}>
+                    <ChromeBorder
+                      radius={8}
+                      thickness={1}
+                      clip
+                      style={styles.searchResultArt}
+                    >
                       <Image
                         source={{ uri: pickedArtwork(track) as string }}
                         style={{ width: "100%", height: "100%" }}
@@ -1022,7 +1243,13 @@ function VoteHeroVideoLayer({ source }: { source: number }) {
   );
 }
 
-function VoteHero({ imageKey, heroHeight }: { imageKey: string; heroHeight: number }) {
+function VoteHero({
+  imageKey,
+  heroHeight,
+}: {
+  imageKey: string;
+  heroHeight: number;
+}) {
   const image = imageForKey(imageKey);
   const video = videoForKey(imageKey);
   const tone = toneForKey(imageKey);
@@ -1084,6 +1311,7 @@ function VotingScreenContent({
   isCommissioner,
   countdown,
   leagueName,
+  extensionControlSlot,
   onVoted,
   onBack,
   onForceEnd,
@@ -1097,6 +1325,7 @@ function VotingScreenContent({
   isCommissioner: boolean;
   countdown: string;
   leagueName?: string;
+  extensionControlSlot?: React.ReactNode;
   onVoted: () => void;
   onBack: () => void;
   onForceEnd: () => void;
@@ -1176,13 +1405,22 @@ function VotingScreenContent({
   // started from) — used to flag the active row.
   const currentPlayingSubId =
     playback.currentIndex !== null
-      ? playback.playlist[playback.currentIndex]?.id ?? null
+      ? (playback.playlist[playback.currentIndex]?.id ?? null)
       : null;
 
-  // TODO(spotify): wire to real "save playlist to Spotify" once the backend
-  // hook exists. Stubbed so the button reads as functional today.
   const onAddToSpotify = () => {
-    Alert.alert("Add to Spotify", "Coming soon — this will save the round playlist to your Spotify account.");
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: "Add",
+          options: ["Cancel", "Add to Spotify"],
+          cancelButtonIndex: 0,
+        },
+        () => {},
+      );
+      return;
+    }
+    Alert.alert("Add", "Add to Spotify");
   };
 
   const adjust = (subId: string, delta: number) => {
@@ -1255,17 +1493,7 @@ function VotingScreenContent({
 
   // Pill (dark) shows round + season; the trailing text (same dark plum
   // ink) shows picks + closes time. Reference: voting page mockup, Nov 2026.
-  const pillLabel = [
-    `R${String(round.round_number).padStart(2, "0")}`,
-    round.seasons?.name ? round.seasons.name.toUpperCase() : "",
-  ]
-    .filter(Boolean)
-    .join(" · ");
-  const metaTail = (() => {
-    const m = countdown.match(/ in (.+)$/);
-    const dur = m ? m[1] : countdown;
-    return `${submissions.length} PICKS · CLOSES ${dur.toUpperCase()}`;
-  })();
+  const dueCopy = formatVotesDueCopy(round.voting_deadline_at);
 
   const { height: screenHeight } = useWindowDimensions();
   const heroHeight = screenHeight * 0.55;
@@ -1286,19 +1514,11 @@ function VotingScreenContent({
             </Text>
             <ChromeText glyph="★" size={22} style={styles.voteTitleStar} />
           </View>
-          <View style={styles.voteMetaRow}>
-            {pillLabel ? (
-              <View style={styles.voteMetaPill}>
-                <Text style={styles.voteMetaPillText} numberOfLines={1}>
-                  {pillLabel}
-                </Text>
-              </View>
-            ) : null}
-            <Text style={styles.voteMetaTail} numberOfLines={1}>
-              {pillLabel ? " · " : ""}
-              {metaTail}
+          {round.description ? (
+            <Text style={styles.voteHeroDescription} numberOfLines={3}>
+              {round.description}
             </Text>
-          </View>
+          ) : null}
         </View>
       </View>
 
@@ -1307,19 +1527,30 @@ function VotingScreenContent({
           on each side (the previous ChromeBorder-wrapped Play button was
           producing visible chrome bands because the inner Pressable didn't
           fill the gradient's content box). */}
-      <View style={styles.voteButtonsRow}>
-        <ChromeButton onPress={onPlay} style={{ flex: 1 }}>
+      <View style={styles.voteControlsRow}>
+        {extensionControlSlot ?? (
+          <BouncyPressable
+            style={[styles.voteCircleControl, styles.voteCircleControlMuted]}
+            disabled
+          >
+            <Clock size={17} color={THEME.ink} strokeWidth={2.6} />
+          </BouncyPressable>
+        )}
+        <BouncyPressable style={styles.votePlayControl} onPress={onPlay}>
           <View style={styles.votePlayTriangle} />
-          <Text style={styles.voteBtnLabelDark}>Play</Text>
-        </ChromeButton>
-        <Pressable
-          style={[styles.voteBtnInner, styles.voteBtnDarkBg]}
+          <Text style={styles.votePlayControlText}>Play</Text>
+        </BouncyPressable>
+        <BouncyPressable
+          style={styles.voteCircleControl}
           onPress={onAddToSpotify}
         >
-          <Text style={styles.voteBtnGlyphLight}>+</Text>
-          <Text style={styles.voteBtnLabelLight}>Add to Spotify</Text>
-        </Pressable>
+          <Plus size={17} color={THEME.ink} strokeWidth={2.6} />
+        </BouncyPressable>
       </View>
+
+      <Text style={styles.voteDueLine} numberOfLines={2}>
+        {dueCopy}
+      </Text>
 
       <View style={styles.votePlaylist}>
         {!didSubmit && !isSpectator ? (
@@ -1369,7 +1600,9 @@ function VotingScreenContent({
           // show committed votes (falling back to the draft until myVotes
           // refetches, so the count never blinks to 0 right after submitting).
           const draftPts = allocation[sub.id] ?? 0;
-          const pts = showSubmittedView ? myVotes[sub.id] ?? draftPts : draftPts;
+          const pts = showSubmittedView
+            ? (myVotes[sub.id] ?? draftPts)
+            : draftPts;
           const isOwn = sub.user_id === userId;
           const plusDisabled =
             submitting ||
@@ -1377,12 +1610,12 @@ function VotingScreenContent({
             remaining === 0 ||
             pts >= maxPerTrack ||
             isOwn;
-          const minusDisabled =
-            submitting || !canEdit || pts === 0 || isOwn;
+          const minusDisabled = submitting || !canEdit || pts === 0 || isOwn;
           const isCommentOpen = expandedCommentId === sub.id;
           const showVoteUI = canEdit && !isOwn;
           const isCurrentTrack = currentPlayingSubId === sub.id;
-          const isPlayable = !!sub.spotify_track_id || !!sub.soundcloud_track_url;
+          const isPlayable =
+            !!sub.spotify_track_id || !!sub.soundcloud_track_url;
 
           return (
             <View key={sub.id}>
@@ -1448,9 +1681,7 @@ function VotingScreenContent({
                       <ChevronUp
                         size={20}
                         strokeWidth={2.5}
-                        color={
-                          plusDisabled ? "rgba(26,8,20,0.25)" : THEME.ink
-                        }
+                        color={plusDisabled ? "rgba(26,8,20,0.25)" : THEME.ink}
                       />
                     </TouchableOpacity>
                     <Text style={styles.voteCount}>{pts}</Text>
@@ -1466,9 +1697,7 @@ function VotingScreenContent({
                       <ChevronDown
                         size={20}
                         strokeWidth={2.5}
-                        color={
-                          minusDisabled ? "rgba(26,8,20,0.25)" : THEME.ink
-                        }
+                        color={minusDisabled ? "rgba(26,8,20,0.25)" : THEME.ink}
                       />
                     </TouchableOpacity>
                   </View>
@@ -1528,115 +1757,123 @@ function VotingScreenContent({
                   and the next one. The Save/Edit button floats inside the
                   textbox on the right; the input pads its right side so the
                   text never runs under the button. */}
-              {canEdit && isCommentOpen ? (() => {
-                const isSaved = savedCommentIds.has(sub.id);
-                const isEditing = editingCommentIds.has(sub.id);
-                // Editable while drafting fresh OR while explicitly editing
-                // a previously-saved comment.
-                const editable = !isSaved || isEditing;
-                const hasDraft =
-                  (commentInputs[sub.id] ?? "").trim().length > 0;
-                // Save needs text when drafting; in editing mode Save is
-                // allowed even with empty text (acts as a delete).
-                const saveDisabled = !isEditing && !hasDraft;
-                return (
-                  <View style={styles.commentAccordion}>
-                    <TextInput
-                      style={[
-                        styles.commentAccordionInput,
-                        !editable && styles.commentAccordionInputSaved,
-                      ]}
-                      value={commentInputs[sub.id] ?? ""}
-                      onChangeText={(v) =>
-                        setCommentInputs((prev) => ({ ...prev, [sub.id]: v }))
-                      }
-                      placeholder="Leave a comment for this track…"
-                      placeholderTextColor={THEME.faint}
-                      multiline
-                      textAlignVertical="top"
-                      autoFocus={editable}
-                      editable={editable}
-                    />
-                    <View
-                      style={styles.commentInlineBtnSlot}
-                      pointerEvents="box-none"
-                    >
-                      {editable ? (
-                        <Pressable
+              {canEdit && isCommentOpen
+                ? (() => {
+                    const isSaved = savedCommentIds.has(sub.id);
+                    const isEditing = editingCommentIds.has(sub.id);
+                    // Editable while drafting fresh OR while explicitly editing
+                    // a previously-saved comment.
+                    const editable = !isSaved || isEditing;
+                    const hasDraft =
+                      (commentInputs[sub.id] ?? "").trim().length > 0;
+                    // Save needs text when drafting; in editing mode Save is
+                    // allowed even with empty text (acts as a delete).
+                    const saveDisabled = !isEditing && !hasDraft;
+                    return (
+                      <View style={styles.commentAccordion}>
+                        <TextInput
                           style={[
-                            styles.commentInlineBtn,
-                            styles.commentPrimaryBtn,
-                            saveDisabled && styles.commentPrimaryBtnDisabled,
+                            styles.commentAccordionInput,
+                            !editable && styles.commentAccordionInputSaved,
                           ]}
-                          onPress={() => {
-                            if (saveDisabled) return;
-                            const text = (commentInputs[sub.id] ?? "").trim();
-                            setSavedCommentIds((prev) => {
-                              const next = new Set(prev);
-                              if (text.length > 0) next.add(sub.id);
-                              else next.delete(sub.id); // empty save = delete
-                              return next;
-                            });
-                            setEditingCommentIds((prev) => {
-                              if (!prev.has(sub.id)) return prev;
-                              const next = new Set(prev);
-                              next.delete(sub.id);
-                              return next;
-                            });
-                            if (text.length === 0) {
-                              setCommentInputs((prev) => ({
-                                ...prev,
-                                [sub.id]: "",
-                              }));
-                            }
-                            LayoutAnimation.configureNext({
-                              duration: 180,
-                              create: {
-                                type: "easeInEaseOut",
-                                property: "opacity",
-                              },
-                              update: { type: "easeInEaseOut" },
-                              delete: {
-                                type: "easeInEaseOut",
-                                property: "opacity",
-                              },
-                            });
-                            setExpandedCommentId(null);
-                          }}
-                          disabled={saveDisabled}
-                          hitSlop={6}
+                          value={commentInputs[sub.id] ?? ""}
+                          onChangeText={(v) =>
+                            setCommentInputs((prev) => ({
+                              ...prev,
+                              [sub.id]: v,
+                            }))
+                          }
+                          placeholder="Leave a comment for this track…"
+                          placeholderTextColor={THEME.faint}
+                          multiline
+                          textAlignVertical="top"
+                          autoFocus={editable}
+                          editable={editable}
+                        />
+                        <View
+                          style={styles.commentInlineBtnSlot}
+                          pointerEvents="box-none"
                         >
-                          <Text style={styles.commentPrimaryBtnText}>
-                            Save
-                          </Text>
-                        </Pressable>
-                      ) : (
-                        <Pressable
-                          style={[
-                            styles.commentInlineBtn,
-                            styles.commentSecondaryBtn,
-                          ]}
-                          onPress={() => {
-                            // Enter editing mode while keeping the saved flag
-                            // intact, so the row indicator stays solid until
-                            // the user commits an empty-Save (= delete).
-                            setEditingCommentIds((prev) => {
-                              const next = new Set(prev);
-                              next.add(sub.id);
-                              return next;
-                            });
-                          }}
-                          hitSlop={6}
-                        >
-                          <Text style={styles.commentSecondaryBtnText}>
-                            Edit
-                          </Text>
-                        </Pressable>
-                      )}
-                    </View>
-                  </View>
-                );
-              })() : null}
+                          {editable ? (
+                            <Pressable
+                              style={[
+                                styles.commentInlineBtn,
+                                styles.commentPrimaryBtn,
+                                saveDisabled &&
+                                  styles.commentPrimaryBtnDisabled,
+                              ]}
+                              onPress={() => {
+                                if (saveDisabled) return;
+                                const text = (
+                                  commentInputs[sub.id] ?? ""
+                                ).trim();
+                                setSavedCommentIds((prev) => {
+                                  const next = new Set(prev);
+                                  if (text.length > 0) next.add(sub.id);
+                                  else next.delete(sub.id); // empty save = delete
+                                  return next;
+                                });
+                                setEditingCommentIds((prev) => {
+                                  if (!prev.has(sub.id)) return prev;
+                                  const next = new Set(prev);
+                                  next.delete(sub.id);
+                                  return next;
+                                });
+                                if (text.length === 0) {
+                                  setCommentInputs((prev) => ({
+                                    ...prev,
+                                    [sub.id]: "",
+                                  }));
+                                }
+                                LayoutAnimation.configureNext({
+                                  duration: 180,
+                                  create: {
+                                    type: "easeInEaseOut",
+                                    property: "opacity",
+                                  },
+                                  update: { type: "easeInEaseOut" },
+                                  delete: {
+                                    type: "easeInEaseOut",
+                                    property: "opacity",
+                                  },
+                                });
+                                setExpandedCommentId(null);
+                              }}
+                              disabled={saveDisabled}
+                              hitSlop={6}
+                            >
+                              <Text style={styles.commentPrimaryBtnText}>
+                                Save
+                              </Text>
+                            </Pressable>
+                          ) : (
+                            <Pressable
+                              style={[
+                                styles.commentInlineBtn,
+                                styles.commentSecondaryBtn,
+                              ]}
+                              onPress={() => {
+                                // Enter editing mode while keeping the saved flag
+                                // intact, so the row indicator stays solid until
+                                // the user commits an empty-Save (= delete).
+                                setEditingCommentIds((prev) => {
+                                  const next = new Set(prev);
+                                  next.add(sub.id);
+                                  return next;
+                                });
+                              }}
+                              hitSlop={6}
+                            >
+                              <Text style={styles.commentSecondaryBtnText}>
+                                Edit
+                              </Text>
+                            </Pressable>
+                          )}
+                        </View>
+                      </View>
+                    );
+                  })()
+                : null}
 
               {/* Subtle hairline so adjacent tracks don't read as one blob.
                   Skipped after the last row — no trailing divider before
@@ -1742,8 +1979,12 @@ function VotingPhase({
   const pointsTotal = round.seasons?.default_points_per_round ?? 10;
   const maxPerTrack = round.seasons?.default_max_points_per_track ?? 5;
 
-  const [allocation, setAllocation] = useState<Record<string, number>>(() => myVotes);
-  const [commentInputs, setCommentInputs] = useState<Record<string, string>>({});
+  const [allocation, setAllocation] = useState<Record<string, number>>(
+    () => myVotes,
+  );
+  const [commentInputs, setCommentInputs] = useState<Record<string, string>>(
+    {},
+  );
   const [justSubmitted, setJustSubmitted] = useState(false);
   const submitMutation = useSubmitVotes();
   const submitting = submitMutation.isPending;
@@ -1777,30 +2018,38 @@ function VotingPhase({
 
   const submitVotes = async () => {
     if (remaining > 0) {
-      Alert.alert('Points not fully spent', `You have ${remaining} point${remaining !== 1 ? 's' : ''} left to allocate.`);
+      Alert.alert(
+        "Points not fully spent",
+        `You have ${remaining} point${remaining !== 1 ? "s" : ""} left to allocate.`,
+      );
       return;
     }
     const votes: VoteInput[] = Object.entries(allocation)
       .filter(([, pts]) => pts > 0)
       .map(([submissionId, points]) => ({ submissionId, points }));
     const comments: VoteCommentInput[] = submissions
-      .filter((s) => (commentInputs[s.id] ?? '').trim().length > 0)
+      .filter((s) => (commentInputs[s.id] ?? "").trim().length > 0)
       .map((s) => ({ submissionId: s.id, body: commentInputs[s.id] }));
 
     try {
-      await submitMutation.mutateAsync({ roundId: round.id, userId, votes, comments });
+      await submitMutation.mutateAsync({
+        roundId: round.id,
+        userId,
+        votes,
+        comments,
+      });
       onScrollToTop?.();
       LayoutAnimation.configureNext({
         duration: 450,
-        create: { type: 'easeInEaseOut', property: 'opacity' },
-        update: { type: 'easeInEaseOut', springDamping: 0.85 },
-        delete: { type: 'easeInEaseOut', property: 'opacity' },
+        create: { type: "easeInEaseOut", property: "opacity" },
+        update: { type: "easeInEaseOut", springDamping: 0.85 },
+        delete: { type: "easeInEaseOut", property: "opacity" },
       });
       setJustSubmitted(true);
       onVoted();
     } catch (err) {
-      const message = err instanceof MixError ? err.message : 'Unknown error';
-      Alert.alert('Submit failed', message);
+      const message = err instanceof MixError ? err.message : "Unknown error";
+      Alert.alert("Submit failed", message);
     }
   };
 
@@ -1810,13 +2059,26 @@ function VotingPhase({
         <View style={styles.spectatorCard}>
           <Text style={styles.spectatorCardTitle}>You&apos;re spectating</Text>
           <Text style={styles.spectatorCardBody}>
-            Sit back — participants are voting on their submissions. Results will show when voting closes.
+            Sit back — participants are voting on their submissions. Results
+            will show when voting closes.
           </Text>
         </View>
         {submissions.map((sub) => (
-          <View key={sub.id} style={[styles.submissionVoteCard, { opacity: 0.5 }]}>
-            <TrackRow title={sub.track_title} artist={sub.track_artist} artwork={sub.track_artwork_url} compact />
-            {!!sub.comment && <Text style={styles.submissionComment}>&ldquo;{sub.comment}&rdquo;</Text>}
+          <View
+            key={sub.id}
+            style={[styles.submissionVoteCard, { opacity: 0.5 }]}
+          >
+            <TrackRow
+              title={sub.track_title}
+              artist={sub.track_artist}
+              artwork={sub.track_artwork_url}
+              compact
+            />
+            {!!sub.comment && (
+              <Text style={styles.submissionComment}>
+                &ldquo;{sub.comment}&rdquo;
+              </Text>
+            )}
           </View>
         ))}
       </View>
@@ -1829,13 +2091,26 @@ function VotingPhase({
         <View style={styles.ineligibleBanner}>
           <Text style={styles.ineligibleTitle}>Not eligible this round</Text>
           <Text style={styles.ineligibleSub}>
-            You didn&apos;t submit a track before the deadline. You can see the submissions but can&apos;t vote.
+            You didn&apos;t submit a track before the deadline. You can see the
+            submissions but can&apos;t vote.
           </Text>
         </View>
         {submissions.map((sub) => (
-          <View key={sub.id} style={[styles.submissionVoteCard, { opacity: 0.5 }]}>
-            <TrackRow title={sub.track_title} artist={sub.track_artist} artwork={sub.track_artwork_url} compact />
-            {!!sub.comment && <Text style={styles.submissionComment}>&ldquo;{sub.comment}&rdquo;</Text>}
+          <View
+            key={sub.id}
+            style={[styles.submissionVoteCard, { opacity: 0.5 }]}
+          >
+            <TrackRow
+              title={sub.track_title}
+              artist={sub.track_artist}
+              artwork={sub.track_artwork_url}
+              compact
+            />
+            {!!sub.comment && (
+              <Text style={styles.submissionComment}>
+                &ldquo;{sub.comment}&rdquo;
+              </Text>
+            )}
           </View>
         ))}
       </View>
@@ -1853,10 +2128,18 @@ function VotingPhase({
         </View>
       ) : (
         <View style={styles.pointsBar}>
-          <Text style={[styles.pointsRemaining, remaining === 0 && { color: THEME.accent }]}>
+          <Text
+            style={[
+              styles.pointsRemaining,
+              remaining === 0 && { color: THEME.accent },
+            ]}
+          >
             {remaining}
           </Text>
-          <Text style={styles.mutedHint}> / {pointsTotal} pts remaining · max {maxPerTrack} per track</Text>
+          <Text style={styles.mutedHint}>
+            {" "}
+            / {pointsTotal} pts remaining · max {maxPerTrack} per track
+          </Text>
         </View>
       )}
 
@@ -1875,24 +2158,41 @@ function VotingPhase({
             style={[
               styles.submissionVoteCard,
               showSubmittedView && voted && styles.submissionVoteCardVoted,
-              showSubmittedView && !voted && !isOwn && styles.submissionVoteCardUnvoted,
+              showSubmittedView &&
+                !voted &&
+                !isOwn &&
+                styles.submissionVoteCardUnvoted,
             ]}
           >
-            <TrackRow title={sub.track_title} artist={sub.track_artist} artwork={sub.track_artwork_url} compact />
-            {!!sub.comment && <Text style={styles.submissionComment}>&ldquo;{sub.comment}&rdquo;</Text>}
+            <TrackRow
+              title={sub.track_title}
+              artist={sub.track_artist}
+              artwork={sub.track_artwork_url}
+              compact
+            />
+            {!!sub.comment && (
+              <Text style={styles.submissionComment}>
+                &ldquo;{sub.comment}&rdquo;
+              </Text>
+            )}
 
             {isOwn ? (
               <Text style={styles.ownTrackLabel}>YOUR TRACK</Text>
             ) : showSubmittedView ? (
               voted ? (
-                <Text style={styles.lockedPts}>{pts} pt{pts !== 1 ? 's' : ''} given</Text>
+                <Text style={styles.lockedPts}>
+                  {pts} pt{pts !== 1 ? "s" : ""} given
+                </Text>
               ) : (
                 <Text style={styles.lockedPtsNone}>— no points</Text>
               )
             ) : (
               <View style={styles.voteStepper}>
                 <TouchableOpacity
-                  style={[styles.voteBtn, minusDisabled && styles.voteBtnDisabled]}
+                  style={[
+                    styles.voteBtn,
+                    minusDisabled && styles.voteBtnDisabled,
+                  ]}
                   onPress={() => adjust(sub.id, -1)}
                   disabled={minusDisabled}
                 >
@@ -1900,7 +2200,10 @@ function VotingPhase({
                 </TouchableOpacity>
                 <Text style={styles.votePoints}>{currentPts}</Text>
                 <TouchableOpacity
-                  style={[styles.voteBtn, plusDisabled && styles.voteBtnDisabled]}
+                  style={[
+                    styles.voteBtn,
+                    plusDisabled && styles.voteBtnDisabled,
+                  ]}
                   onPress={() => adjust(sub.id, 1)}
                   disabled={plusDisabled}
                 >
@@ -1912,8 +2215,10 @@ function VotingPhase({
             {!showSubmittedView && (
               <TextInput
                 style={styles.commentInputField}
-                value={commentInputs[sub.id] ?? ''}
-                onChangeText={(v) => setCommentInputs((prev) => ({ ...prev, [sub.id]: v }))}
+                value={commentInputs[sub.id] ?? ""}
+                onChangeText={(v) =>
+                  setCommentInputs((prev) => ({ ...prev, [sub.id]: v }))
+                }
                 placeholder="Leave a comment… (optional)"
                 placeholderTextColor={THEME.faint}
                 multiline
@@ -2111,7 +2416,8 @@ function ResultsPhase({
           const upperPrompt = round.prompt.toUpperCase();
           const lastSpace = upperPrompt.lastIndexOf(" ");
           const head = lastSpace > 0 ? upperPrompt.slice(0, lastSpace) : "";
-          const tail = lastSpace > 0 ? upperPrompt.slice(lastSpace + 1) : upperPrompt;
+          const tail =
+            lastSpace > 0 ? upperPrompt.slice(lastSpace + 1) : upperPrompt;
           return (
             <View style={styles.resultsTitleRow}>
               {head ? (
@@ -2149,9 +2455,21 @@ function ResultsPhase({
       {/* ── Podium (top 3) ─────────────────────────────────────────────── */}
       {top3.length > 0 ? (
         <View style={styles.podiumRow}>
-          <PodiumColumn rank={2} entry={top3[1]} topPoints={top3[0]?.points_effective ?? 1} />
-          <PodiumColumn rank={1} entry={top3[0]} topPoints={top3[0]?.points_effective ?? 1} />
-          <PodiumColumn rank={3} entry={top3[2]} topPoints={top3[0]?.points_effective ?? 1} />
+          <PodiumColumn
+            rank={2}
+            entry={top3[1]}
+            topPoints={top3[0]?.points_effective ?? 1}
+          />
+          <PodiumColumn
+            rank={1}
+            entry={top3[0]}
+            topPoints={top3[0]?.points_effective ?? 1}
+          />
+          <PodiumColumn
+            rank={3}
+            entry={top3[2]}
+            topPoints={top3[0]?.points_effective ?? 1}
+          />
         </View>
       ) : null}
 
@@ -2299,9 +2617,7 @@ function PodiumColumn({
         end={{ x: 1, y: 1 }}
         style={[styles.podiumBar, { height: barHeight }]}
       >
-        <Text style={styles.podiumBarPts}>
-          +{entry.points_effective}
-        </Text>
+        <Text style={styles.podiumBarPts}>+{entry.points_effective}</Text>
         <Text style={styles.podiumBarOrdinal}>{RANK_ORDINAL[rank]}</Text>
       </LinearGradient>
     </View>
@@ -2342,9 +2658,7 @@ function ResultCard({
   // a regular numeric place chip; forfeits get no place marker.
   const isPodiumPlace = place === 1 || place === 2 || place === 3;
   return (
-    <View
-      style={[styles.resultCard, forfeit && styles.resultCardForfeit]}
-    >
+    <View style={[styles.resultCard, forfeit && styles.resultCardForfeit]}>
       <View style={styles.resultCardHeader}>
         <View style={styles.resultCardArtWrap}>
           {row.track_artwork_url ? (
@@ -2477,8 +2791,11 @@ export function RoundScreen({
   const userId = supabaseUserId;
   const bottomInset = useTabBarBottomInset();
 
-  const { data: round, isLoading: roundLoading, refetch: refetchRound } =
-    useRound(roundId);
+  const {
+    data: round,
+    isLoading: roundLoading,
+    refetch: refetchRound,
+  } = useRound(roundId);
   const roundSeasonId = round?.season_id;
   const leagueId = round?.seasons?.league_id;
 
@@ -2640,6 +2957,15 @@ export function RoundScreen({
               isCommissioner={isCommissioner}
               countdown={countdown}
               leagueName={league?.name}
+              extensionControlSlot={
+                myRole === "spectator" ? undefined : (
+                  <DeadlineExtensionControlButton
+                    roundId={round.id}
+                    userId={userId}
+                    deadlineType="voting"
+                  />
+                )
+              }
               onVoted={() => {
                 void refetchRound();
                 scrollToTop();
@@ -2668,11 +2994,7 @@ export function RoundScreen({
           options={{
             headerTitle: () => (
               <View style={styles.heroTopPill}>
-                <ChromeText
-                  glyph="✦"
-                  size={9}
-                  style={{ marginRight: 6 }}
-                />
+                <ChromeText glyph="✦" size={9} style={{ marginRight: 6 }} />
                 <Text style={styles.heroTopPillText} numberOfLines={1}>
                   R{pickNum} · SUBMIT
                   {leagueName ? ` · ${leagueName.toUpperCase()}` : ""}
@@ -2701,6 +3023,11 @@ export function RoundScreen({
               }
             >
               <SubmissionsHero round={round} countdown={countdown} />
+              <DeadlineExtensionCard
+                roundId={round.id}
+                userId={userId}
+                deadlineType="submission"
+              />
               <SubmissionPhase
                 round={round}
                 userId={userId}
@@ -2719,49 +3046,51 @@ export function RoundScreen({
     return (
       <Wallpaper halftone={false}>
         <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
-        <ScrollView
-          ref={scrollViewRef}
-          style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={onRefresh}
-              tintColor={THEME.ink}
-            />
-          }
-        >
-          {round.seasons?.status === "completed" &&
-            round.round_number === totalRounds && (
-              <TouchableOpacity
-                style={styles.seasonCompleteBanner}
-                onPress={() =>
-                  router.push({
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    pathname: "/(tabs)/(home)/season/[id]" as any,
-                    params: { id: round.season_id, initialTab: "standings" },
-                  })
-                }
-                activeOpacity={0.8}
-              >
-                <Text style={styles.seasonCompleteEmoji}>🏆</Text>
-                <View style={styles.seasonCompleteText}>
-                  <Text style={styles.seasonCompleteTitle}>Season complete!</Text>
-                  <Text style={styles.seasonCompleteSub}>
-                    See the final standings →
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            )}
+          <ScrollView
+            ref={scrollViewRef}
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingBottom: bottomInset + 24 }}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={onRefresh}
+                tintColor={THEME.ink}
+              />
+            }
+          >
+            {round.seasons?.status === "completed" &&
+              round.round_number === totalRounds && (
+                <TouchableOpacity
+                  style={styles.seasonCompleteBanner}
+                  onPress={() =>
+                    router.push({
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      pathname: "/(tabs)/(home)/season/[id]" as any,
+                      params: { id: round.season_id, initialTab: "standings" },
+                    })
+                  }
+                  activeOpacity={0.8}
+                >
+                  <Text style={styles.seasonCompleteEmoji}>🏆</Text>
+                  <View style={styles.seasonCompleteText}>
+                    <Text style={styles.seasonCompleteTitle}>
+                      Season complete!
+                    </Text>
+                    <Text style={styles.seasonCompleteSub}>
+                      See the final standings →
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              )}
 
-          <ResultsPhase
-            round={round}
-            submissions={submissions}
-            leagueName={league?.name}
-            totalRounds={totalRounds}
-            onBack={() => router.back()}
-          />
-        </ScrollView>
+            <ResultsPhase
+              round={round}
+              submissions={submissions}
+              leagueName={league?.name}
+              totalRounds={totalRounds}
+              onBack={() => router.back()}
+            />
+          </ScrollView>
         </SafeAreaView>
       </Wallpaper>
     );
@@ -2831,6 +3160,22 @@ export function RoundScreen({
               </Text>
             </Text>
           </View>
+
+          {userId && myRole !== "spectator" && phase === "submissions" ? (
+            <DeadlineExtensionCard
+              roundId={round.id}
+              userId={userId}
+              deadlineType="submission"
+            />
+          ) : null}
+
+          {userId && myRole !== "spectator" && phase === "voting" ? (
+            <DeadlineExtensionCard
+              roundId={round.id}
+              userId={userId}
+              deadlineType="voting"
+            />
+          ) : null}
 
           {phase === "upcoming" && prevRound && (
             <View style={styles.upcomingCard}>
@@ -2995,6 +3340,105 @@ const styles = StyleSheet.create({
   themedBtnText: {
     fontFamily: THEME.fonts.sansSemi,
     fontSize: 14,
+  },
+
+  // Deadline extension request
+  extensionCard: {
+    backgroundColor: "rgba(255,255,255,0.58)",
+    borderRadius: 16,
+    padding: 14,
+    gap: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(26,8,20,0.16)",
+  },
+  extensionHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  extensionEyebrow: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 10,
+    letterSpacing: 1.2,
+    color: THEME.faint,
+  },
+  extensionTitle: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 15,
+    color: THEME.ink,
+    marginTop: 2,
+  },
+  extensionPrompt: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 12,
+    letterSpacing: 1.2,
+    color: THEME.faint,
+    textTransform: "uppercase",
+  },
+  extensionByline: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 12,
+    color: THEME.muted,
+    marginTop: 3,
+  },
+  extensionDuration: {
+    fontFamily: THEME.fonts.monoBold,
+    fontSize: 12,
+    color: THEME.ink,
+    paddingHorizontal: 9,
+    paddingVertical: 5,
+    borderRadius: 999,
+    overflow: "hidden",
+    backgroundColor: "rgba(26,8,20,0.08)",
+  },
+  extensionBody: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 12,
+    color: THEME.muted,
+    lineHeight: 17,
+  },
+  extensionLimit: {
+    fontFamily: THEME.fonts.serifItalic,
+    fontSize: 12,
+    color: THEME.faint,
+    lineHeight: 17,
+  },
+  extensionWarning: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 12,
+    color: THEME.accent,
+  },
+  extensionActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
+    flexWrap: "wrap",
+    flexShrink: 0,
+  },
+  extensionButton: {
+    borderRadius: 999,
+    backgroundColor: THEME.ink,
+    paddingHorizontal: 14,
+    height: 40,
+    minWidth: 118,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  extensionButtonSecondary: {
+    backgroundColor: "transparent",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(26,8,20,0.24)",
+  },
+  extensionButtonDisabled: {
+    opacity: 0.45,
+  },
+  extensionButtonText: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 12,
+    color: "#fff",
+  },
+  extensionButtonSecondaryText: {
+    color: THEME.ink,
   },
 
   // Points
@@ -3749,15 +4193,61 @@ const styles = StyleSheet.create({
     letterSpacing: 1.6,
     color: THEME.ink,
   },
-  voteButtonsRow: {
-    flexDirection: "row",
-    gap: 10,
-    paddingHorizontal: 22,
-    // Pulled snug against the bottom of the hero rectangle. The video has
-    // already faded to transparent there, so the buttons sit on the wash
-    // immediately below the (invisible) bottom edge of the hero.
-    marginTop: 8,
+  voteDueLine: {
+    fontFamily: THEME.fonts.sansSemi,
+    fontSize: 13,
+    lineHeight: 18,
+    color: THEME.ink,
+    textAlign: "center",
+    paddingHorizontal: 28,
     marginBottom: 18,
+  },
+  voteHeroDescription: {
+    fontFamily: THEME.fonts.sansMedium,
+    fontSize: 15,
+    lineHeight: 20,
+    color: "rgba(26,8,20,0.52)",
+    textAlign: "center",
+    marginTop: -1,
+  },
+  voteControlsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    paddingHorizontal: 34,
+    marginTop: 12,
+    marginBottom: 14,
+  },
+  voteCircleControl: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.72)",
+  },
+  voteCircleControlMuted: {
+    opacity: 0.45,
+  },
+  voteCircleControlActive: {
+    backgroundColor: THEME.ink,
+    opacity: 1,
+  },
+  votePlayControl: {
+    minWidth: 155,
+    height: 46,
+    borderRadius: 23,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 7,
+    backgroundColor: "#050405",
+  },
+  votePlayControlText: {
+    fontFamily: THEME.fonts.sansBold,
+    fontSize: 13,
+    color: "#fff",
   },
   voteBtnInner: {
     flex: 1,
@@ -3792,12 +4282,12 @@ const styles = StyleSheet.create({
   votePlayTriangle: {
     width: 0,
     height: 0,
-    borderTopWidth: 7,
-    borderBottomWidth: 7,
-    borderLeftWidth: 10,
+    borderTopWidth: 6,
+    borderBottomWidth: 6,
+    borderLeftWidth: 9,
     borderTopColor: "transparent",
     borderBottomColor: "transparent",
-    borderLeftColor: THEME.ink,
+    borderLeftColor: "#fff",
     marginLeft: 2,
   },
   voteBtnGlyphLight: {
@@ -3808,6 +4298,10 @@ const styles = StyleSheet.create({
 
   // ─── Voting playlist (Bubblegum hero+playlist layout) ────────────────────
 
+  voteExtensionWrap: {
+    paddingHorizontal: 18,
+    paddingTop: 10,
+  },
   votePlaylist: {
     paddingHorizontal: 18,
     paddingTop: 4,
@@ -3974,7 +4468,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     paddingLeft: 12,
     paddingRight: 84, // reserved gutter so the typed text never collides
-                      // with the absolute-positioned Save/Edit button on the right
+    // with the absolute-positioned Save/Edit button on the right
     paddingVertical: 10,
     color: THEME.ink,
     fontFamily: THEME.fonts.sans,

--- a/apps/mobile/src/services/deadlineExtensions.ts
+++ b/apps/mobile/src/services/deadlineExtensions.ts
@@ -1,0 +1,217 @@
+import { supabase } from "@/lib/supabase";
+import { postgresToMixError } from "./errors";
+
+export type DeadlineExtensionType = "submission" | "voting";
+
+export type DeadlineExtensionState = {
+  roundId: string;
+  deadlineType: DeadlineExtensionType;
+  enabled: boolean;
+  thresholdPercent: number;
+  durationMinutes: number;
+  maxExtensionsPerPhase: number | null;
+  eligibleCount: number;
+  requestedCount: number;
+  thresholdCount: number;
+  userRequested: boolean;
+  extensionCount: number;
+  extensionLimitReached: boolean;
+  closesWithinExtensionWindow: boolean;
+  extensionAllowed: boolean;
+  lastOutcome: "extended" | "blocked" | null;
+  lastReason: string | null;
+  lastNewDeadline: string | null;
+};
+
+type RoundExtensionConfigRow = {
+  id: string;
+  season_id: string;
+  round_number: number;
+  submission_deadline_at: string;
+  voting_deadline_at: string;
+  seasons:
+    | {
+        league_id: string;
+        deadline_extension_enabled: boolean | null;
+        deadline_extension_threshold_percent: number | null;
+        deadline_extension_duration_minutes: number | null;
+        deadline_extension_max_per_phase: number | null;
+      }
+    | Array<{
+        league_id: string;
+        deadline_extension_enabled: boolean | null;
+        deadline_extension_threshold_percent: number | null;
+        deadline_extension_duration_minutes: number | null;
+        deadline_extension_max_per_phase: number | null;
+      }>
+    | null;
+};
+
+type ExtensionLogRow = {
+  outcome: "extended" | "blocked";
+  reason: string | null;
+  new_deadline: string | null;
+};
+
+function normalizeSeason(row: RoundExtensionConfigRow) {
+  return Array.isArray(row.seasons) ? row.seasons[0] : row.seasons;
+}
+
+function thresholdCount(
+  eligibleCount: number,
+  thresholdPercent: number,
+): number {
+  if (eligibleCount <= 0) return 0;
+  return Math.max(1, Math.ceil((eligibleCount * thresholdPercent) / 100));
+}
+
+export async function getDeadlineExtensionState(
+  roundId: string,
+  deadlineType: DeadlineExtensionType,
+  userId: string,
+): Promise<DeadlineExtensionState | null> {
+  const { data: roundData, error: roundError } = await supabase
+    .from("rounds")
+    .select(
+      "id, season_id, round_number, submission_deadline_at, voting_deadline_at, seasons(league_id, deadline_extension_enabled, deadline_extension_threshold_percent, deadline_extension_duration_minutes, deadline_extension_max_per_phase)" as string,
+    )
+    .eq("id", roundId)
+    .single();
+  if (roundError) {
+    if (roundError.code === "PGRST116") return null;
+    throw postgresToMixError(roundError);
+  }
+
+  const round = roundData as unknown as RoundExtensionConfigRow;
+  const season = normalizeSeason(round);
+  if (!season) return null;
+
+  let nextSubmissionDeadline: string | null = null;
+  if (deadlineType === "voting") {
+    const { data: nextRound, error: nextRoundError } = await supabase
+      .from("rounds")
+      .select("submission_deadline_at")
+      .eq("season_id", round.season_id)
+      .eq("round_number", round.round_number + 1)
+      .maybeSingle();
+    if (nextRoundError) throw postgresToMixError(nextRoundError);
+    nextSubmissionDeadline = nextRound?.submission_deadline_at ?? null;
+  }
+
+  const [eligibleResult, requestsResult, logsResult] = await Promise.all([
+    supabase
+      .from("league_members")
+      .select("user_id", { count: "exact" })
+      .eq("league_id", season.league_id)
+      .eq("role", "participant"),
+    supabase
+      .from("deadline_extension_requests")
+      .select("user_id")
+      .eq("round_id", roundId)
+      .eq("deadline_type", deadlineType),
+    supabase
+      .from("deadline_extension_log")
+      .select("outcome, reason, new_deadline")
+      .eq("round_id", roundId)
+      .eq("deadline_type", deadlineType)
+      .order("triggered_at", { ascending: false }),
+  ]);
+
+  if (eligibleResult.error) throw postgresToMixError(eligibleResult.error);
+  if (requestsResult.error) throw postgresToMixError(requestsResult.error);
+  if (logsResult.error) throw postgresToMixError(logsResult.error);
+
+  const eligibleCount =
+    eligibleResult.count ?? eligibleResult.data?.length ?? 0;
+  const requests = requestsResult.data ?? [];
+  const logs = (logsResult.data ?? []) as unknown as ExtensionLogRow[];
+  const percent = season.deadline_extension_threshold_percent ?? 33;
+  const durationMinutes = season.deadline_extension_duration_minutes ?? 1440;
+  const maxExtensions = season.deadline_extension_max_per_phase ?? null;
+  const extensionCount = logs.filter(
+    (log) => log.outcome === "extended",
+  ).length;
+  const lastLog = logs[0];
+  const activeDeadline =
+    deadlineType === "submission"
+      ? round.submission_deadline_at
+      : round.voting_deadline_at;
+  const capDeadline =
+    deadlineType === "submission"
+      ? round.voting_deadline_at
+      : nextSubmissionDeadline;
+  const activeDeadlineMs = new Date(activeDeadline).getTime();
+  const durationMs = durationMinutes * 60_000;
+  const nowMs = Date.now();
+  const capDeadlineMs = capDeadline ? new Date(capDeadline).getTime() : null;
+  const extensionDeadlineMs = activeDeadlineMs + durationMs;
+  const closesWithinExtensionWindow =
+    activeDeadlineMs > nowMs && activeDeadlineMs - nowMs < durationMs;
+  const extensionAllowed =
+    activeDeadlineMs > nowMs &&
+    (capDeadlineMs === null || extensionDeadlineMs <= capDeadlineMs);
+
+  return {
+    roundId,
+    deadlineType,
+    enabled: season.deadline_extension_enabled ?? true,
+    thresholdPercent: percent,
+    durationMinutes,
+    maxExtensionsPerPhase: maxExtensions,
+    eligibleCount,
+    requestedCount: requests.length,
+    thresholdCount: thresholdCount(eligibleCount, percent),
+    userRequested: requests.some((request) => request.user_id === userId),
+    extensionCount,
+    extensionLimitReached:
+      maxExtensions !== null && extensionCount >= maxExtensions,
+    closesWithinExtensionWindow,
+    extensionAllowed,
+    lastOutcome: lastLog?.outcome ?? null,
+    lastReason: lastLog?.reason ?? null,
+    lastNewDeadline: lastLog?.new_deadline ?? null,
+  };
+}
+
+export async function requestDeadlineExtension(args: {
+  roundId: string;
+  deadlineType: DeadlineExtensionType;
+  userId: string;
+}): Promise<void> {
+  const { error } = await (supabase.rpc as any)("request_deadline_extension", {
+    p_round_id: args.roundId,
+    p_deadline_type: args.deadlineType,
+    p_user_id: args.userId,
+  });
+  if (error) throw postgresToMixError(error);
+}
+
+export async function cancelDeadlineExtensionRequest(args: {
+  roundId: string;
+  deadlineType: DeadlineExtensionType;
+  userId: string;
+}): Promise<void> {
+  const { error } = await (supabase.rpc as any)(
+    "cancel_deadline_extension_request",
+    {
+      p_round_id: args.roundId,
+      p_deadline_type: args.deadlineType,
+      p_user_id: args.userId,
+    },
+  );
+  if (error) throw postgresToMixError(error);
+}
+
+export async function commissionerExtendDeadline(args: {
+  roundId: string;
+  deadlineType: DeadlineExtensionType;
+}): Promise<void> {
+  const { error } = await (supabase.rpc as any)(
+    "commissioner_extend_deadline",
+    {
+      p_round_id: args.roundId,
+      p_deadline_type: args.deadlineType,
+    },
+  );
+  if (error) throw postgresToMixError(error);
+}

--- a/apps/mobile/src/services/seasons.ts
+++ b/apps/mobile/src/services/seasons.ts
@@ -12,6 +12,10 @@ export type Season = {
   submissions_per_user: number;
   default_points_per_round: number;
   default_max_points_per_track: number;
+  deadline_extension_enabled: boolean;
+  deadline_extension_threshold_percent: number;
+  deadline_extension_duration_minutes: number;
+  deadline_extension_max_per_phase: number | null;
   leagues: {
     id: string;
     name: string;
@@ -31,7 +35,7 @@ export type SeasonListItem = {
 // so supabase-js's select-parser rejects this select. Cast through unknown
 // until types are regenerated.
 const SEASON_SELECT =
-  "id, name, season_number, status, league_id, submissions_per_user, default_points_per_round, default_max_points_per_track, leagues(id, name, admin_user_id)";
+  "id, name, season_number, status, league_id, submissions_per_user, default_points_per_round, default_max_points_per_track, deadline_extension_enabled, deadline_extension_threshold_percent, deadline_extension_duration_minutes, deadline_extension_max_per_phase, leagues(id, name, admin_user_id)";
 
 type SeasonRow = Omit<Season, "leagues"> & {
   leagues: Season["leagues"] | Season["leagues"][];
@@ -107,6 +111,10 @@ export type CreateSeasonArgs = {
   submissionsPerUser: number;
   defaultPointsPerRound: number;
   defaultMaxPointsPerTrack: number;
+  deadlineExtensionEnabled?: boolean;
+  deadlineExtensionThresholdPercent?: number;
+  deadlineExtensionDurationMinutes?: number;
+  deadlineExtensionMaxPerPhase?: number | null;
   rounds: CreateSeasonRoundInput[];
 };
 
@@ -138,6 +146,13 @@ export async function createSeason(
       submissions_per_user: args.submissionsPerUser,
       default_points_per_round: args.defaultPointsPerRound,
       default_max_points_per_track: args.defaultMaxPointsPerTrack,
+      deadline_extension_enabled: args.deadlineExtensionEnabled ?? true,
+      deadline_extension_threshold_percent:
+        args.deadlineExtensionThresholdPercent ?? 33,
+      deadline_extension_duration_minutes:
+        args.deadlineExtensionDurationMinutes ?? 1440,
+      deadline_extension_max_per_phase:
+        args.deadlineExtensionMaxPerPhase ?? null,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any)
     .select("id")

--- a/apps/mobile/src/ui/BouncyPressable.tsx
+++ b/apps/mobile/src/ui/BouncyPressable.tsx
@@ -1,0 +1,54 @@
+import { useRef } from "react";
+import {
+  Animated,
+  Pressable,
+  type PressableProps,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+type BouncyPressableProps = PressableProps & {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  pressedScale?: number;
+};
+
+export function BouncyPressable({
+  children,
+  disabled,
+  onPressIn,
+  onPressOut,
+  pressedScale = 1.08,
+  style,
+  ...props
+}: BouncyPressableProps) {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  const animateTo = (value: number) => {
+    Animated.spring(scale, {
+      toValue: value,
+      useNativeDriver: true,
+      speed: 34,
+      bounciness: 7,
+    }).start();
+  };
+
+  return (
+    <Pressable
+      {...props}
+      disabled={disabled}
+      onPressIn={(event) => {
+        if (!disabled) animateTo(pressedScale);
+        onPressIn?.(event);
+      }}
+      onPressOut={(event) => {
+        if (!disabled) animateTo(1);
+        onPressOut?.(event);
+      }}
+    >
+      <Animated.View style={[style, { transform: [{ scale }] }]}>
+        {children}
+      </Animated.View>
+    </Pressable>
+  );
+}

--- a/supabase/migrations/20260530000001_deadline_extension_voting.sql
+++ b/supabase/migrations/20260530000001_deadline_extension_voting.sql
@@ -1,0 +1,545 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Deadline extension voting v2
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Issue #24: participants can request an extension for the active round phase.
+-- Defaults are intentionally permissive for MVP:
+--   - 33% of eligible participants, rounded up
+--   - 24 hour extension duration
+--   - unlimited extensions per phase, bounded by timeline hard walls
+--
+-- The hard wall is the true upper limit: submission extensions cannot pass the
+-- same round's voting deadline, and voting extensions cannot pass the next
+-- round's submission deadline.
+
+ALTER TABLE public.seasons
+  ADD COLUMN IF NOT EXISTS deadline_extension_enabled boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS deadline_extension_threshold_percent int NOT NULL DEFAULT 33
+    CHECK (deadline_extension_threshold_percent BETWEEN 1 AND 100),
+  ADD COLUMN IF NOT EXISTS deadline_extension_duration_minutes int NOT NULL DEFAULT 1440
+    CHECK (deadline_extension_duration_minutes BETWEEN 1 AND 10080),
+  ADD COLUMN IF NOT EXISTS deadline_extension_max_per_phase int DEFAULT NULL
+    CHECK (deadline_extension_max_per_phase IS NULL OR deadline_extension_max_per_phase >= 0);
+
+ALTER TABLE public.deadline_extension_log
+  ADD COLUMN IF NOT EXISTS extension_minutes int,
+  ADD COLUMN IF NOT EXISTS triggered_by text NOT NULL DEFAULT 'vote_threshold'
+    CHECK (triggered_by IN ('vote_threshold', 'commissioner')),
+  ADD COLUMN IF NOT EXISTS triggered_by_user_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS requested_count int,
+  ADD COLUMN IF NOT EXISTS threshold_count int,
+  ADD COLUMN IF NOT EXISTS capped_by_round_id uuid REFERENCES public.rounds(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS reason text;
+
+UPDATE public.deadline_extension_log
+   SET extension_minutes = COALESCE(extension_minutes, extension_hours * 60)
+ WHERE extension_minutes IS NULL;
+
+ALTER TABLE public.deadline_extension_log
+  ALTER COLUMN extension_minutes SET DEFAULT 1440,
+  ALTER COLUMN extension_minutes SET NOT NULL;
+
+-- Replace the initial broad policies with league-scoped policies.
+DROP POLICY IF EXISTS "ext_requests_select" ON public.deadline_extension_requests;
+DROP POLICY IF EXISTS "ext_requests_insert" ON public.deadline_extension_requests;
+DROP POLICY IF EXISTS "ext_requests_delete" ON public.deadline_extension_requests;
+DROP POLICY IF EXISTS "ext_log_select" ON public.deadline_extension_log;
+
+CREATE POLICY "League members can view extension requests"
+  ON public.deadline_extension_requests FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+        FROM public.rounds r
+        JOIN public.seasons s ON s.id = r.season_id
+        JOIN public.league_members lm ON lm.league_id = s.league_id
+       WHERE r.id = deadline_extension_requests.round_id
+         AND lm.user_id = auth.uid()
+    )
+  );
+
+-- No INSERT/DELETE policies on request rows: mutations must go through the
+-- RPCs below so threshold checks and deadline updates stay atomic.
+
+CREATE POLICY "League members can view extension log"
+  ON public.deadline_extension_log FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+        FROM public.rounds r
+        JOIN public.seasons s ON s.id = r.season_id
+        JOIN public.league_members lm ON lm.league_id = s.league_id
+       WHERE r.id = deadline_extension_log.round_id
+         AND lm.user_id = auth.uid()
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public._apply_deadline_extension(
+  p_round_id uuid,
+  p_deadline_type text,
+  p_triggered_by text,
+  p_triggered_by_user_id uuid,
+  p_force boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_round_id uuid;
+  v_season_id uuid;
+  v_round_number int;
+  v_submission_deadline timestamptz;
+  v_voting_deadline timestamptz;
+  v_league_id uuid;
+  v_admin_user_id uuid;
+  v_enabled boolean;
+  v_threshold_percent int;
+  v_duration_minutes int;
+  v_max_per_phase int;
+  v_eligible_count int;
+  v_requested_count int;
+  v_threshold_count int;
+  v_existing_extensions int;
+  v_previous_deadline timestamptz;
+  v_uncapped_deadline timestamptz;
+  v_new_deadline timestamptz;
+  v_cap_deadline timestamptz;
+  v_cap_round_id uuid;
+  v_log_outcome text;
+  v_reason text;
+  v_min_extension interval := interval '30 minutes';
+BEGIN
+  IF p_deadline_type NOT IN ('submission', 'voting') THEN
+    RAISE EXCEPTION 'Unsupported deadline type: %', p_deadline_type;
+  END IF;
+
+  IF p_triggered_by NOT IN ('vote_threshold', 'commissioner') THEN
+    RAISE EXCEPTION 'Unsupported extension trigger: %', p_triggered_by;
+  END IF;
+
+  SELECT r.id,
+         r.season_id,
+         r.round_number,
+         r.submission_deadline_at,
+         r.voting_deadline_at,
+         s.league_id,
+         l.admin_user_id,
+         s.deadline_extension_enabled,
+         s.deadline_extension_threshold_percent,
+         s.deadline_extension_duration_minutes,
+         s.deadline_extension_max_per_phase
+    INTO v_round_id,
+         v_season_id,
+         v_round_number,
+         v_submission_deadline,
+         v_voting_deadline,
+         v_league_id,
+         v_admin_user_id,
+         v_enabled,
+         v_threshold_percent,
+         v_duration_minutes,
+         v_max_per_phase
+    FROM public.rounds r
+    JOIN public.seasons s ON s.id = r.season_id
+    JOIN public.leagues l ON l.id = s.league_id
+   WHERE r.id = p_round_id
+   FOR UPDATE OF r;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Round not found';
+  END IF;
+
+  IF NOT v_enabled THEN
+    RAISE EXCEPTION 'Deadline extensions are disabled for this season';
+  END IF;
+
+  SELECT COUNT(*) INTO v_eligible_count
+    FROM public.league_members
+   WHERE league_id = v_league_id
+     AND role = 'participant';
+
+  IF v_eligible_count <= 0 THEN
+    RAISE EXCEPTION 'No eligible participants for this round';
+  END IF;
+
+  v_threshold_count := GREATEST(1, CEIL(v_eligible_count * v_threshold_percent / 100.0)::int);
+
+  SELECT COUNT(*) INTO v_requested_count
+    FROM public.deadline_extension_requests
+   WHERE round_id = p_round_id
+     AND deadline_type = p_deadline_type;
+
+  IF p_deadline_type = 'submission' THEN
+    IF now() >= v_submission_deadline THEN
+      RAISE EXCEPTION 'Submission extension requests are closed for this round';
+    END IF;
+
+    IF v_round_number > 1 AND EXISTS (
+      SELECT 1
+        FROM public.rounds prev
+       WHERE prev.season_id = v_season_id
+         AND prev.round_number = v_round_number - 1
+         AND prev.voting_deadline_at > now()
+    ) THEN
+      RAISE EXCEPTION 'This round is not open for submissions yet';
+    END IF;
+
+    v_previous_deadline := v_submission_deadline;
+    v_cap_deadline := v_voting_deadline;
+    v_cap_round_id := p_round_id;
+  ELSE
+    IF now() < v_submission_deadline THEN
+      RAISE EXCEPTION 'Voting has not opened for this round';
+    END IF;
+
+    IF now() >= v_voting_deadline THEN
+      RAISE EXCEPTION 'Voting extension requests are closed for this round';
+    END IF;
+
+    v_previous_deadline := v_voting_deadline;
+
+    SELECT next.id, next.submission_deadline_at
+      INTO v_cap_round_id, v_cap_deadline
+      FROM public.rounds next
+     WHERE next.season_id = v_season_id
+       AND next.round_number = v_round_number + 1
+     LIMIT 1;
+  END IF;
+
+  IF NOT p_force AND v_requested_count < v_threshold_count THEN
+    RETURN jsonb_build_object(
+      'outcome', 'pending',
+      'requested_count', v_requested_count,
+      'threshold_count', v_threshold_count
+    );
+  END IF;
+
+  SELECT COUNT(*) INTO v_existing_extensions
+    FROM public.deadline_extension_log
+   WHERE round_id = p_round_id
+     AND deadline_type = p_deadline_type
+     AND outcome = 'extended';
+
+  IF v_max_per_phase IS NOT NULL AND v_existing_extensions >= v_max_per_phase THEN
+    v_log_outcome := 'blocked';
+    v_reason := 'max_extensions_reached';
+  END IF;
+
+  v_uncapped_deadline := v_previous_deadline + make_interval(mins => v_duration_minutes);
+  v_new_deadline := CASE
+    WHEN v_cap_deadline IS NULL THEN v_uncapped_deadline
+    ELSE LEAST(v_uncapped_deadline, v_cap_deadline)
+  END;
+
+  IF v_log_outcome IS NULL
+     AND v_cap_deadline IS NOT NULL
+     AND v_uncapped_deadline > v_cap_deadline
+  THEN
+    v_log_outcome := 'blocked';
+    v_reason := 'deadline_boundary_reached';
+  END IF;
+
+  IF v_log_outcome IS NULL AND v_new_deadline <= v_previous_deadline + v_min_extension THEN
+    v_log_outcome := 'blocked';
+    v_reason := 'deadline_boundary_reached';
+  END IF;
+
+  IF v_log_outcome = 'blocked' THEN
+    INSERT INTO public.deadline_extension_log (
+      round_id,
+      deadline_type,
+      outcome,
+      previous_deadline,
+      new_deadline,
+      extension_hours,
+      extension_minutes,
+      triggered_by,
+      triggered_by_user_id,
+      requested_count,
+      threshold_count,
+      capped_by_round_id,
+      reason
+    ) VALUES (
+      p_round_id,
+      p_deadline_type,
+      'blocked',
+      v_previous_deadline,
+      NULL,
+      CEIL(v_duration_minutes / 60.0)::int,
+      v_duration_minutes,
+      p_triggered_by,
+      p_triggered_by_user_id,
+      v_requested_count,
+      v_threshold_count,
+      v_cap_round_id,
+      v_reason
+    );
+
+    DELETE FROM public.deadline_extension_requests
+     WHERE round_id = p_round_id
+       AND deadline_type = p_deadline_type;
+
+    INSERT INTO public.notifications (user_id, type, title, body, data)
+    VALUES (
+      v_admin_user_id,
+      'deadline_extension_blocked',
+      'Extension blocked',
+      'An extension request hit a season timeline limit.',
+      jsonb_build_object(
+        'round_id', p_round_id,
+        'season_id', v_season_id,
+        'league_id', v_league_id,
+        'deadline_type', p_deadline_type,
+        'reason', v_reason
+      )
+    );
+
+    RETURN jsonb_build_object(
+      'outcome', 'blocked',
+      'reason', v_reason,
+      'requested_count', v_requested_count,
+      'threshold_count', v_threshold_count
+    );
+  END IF;
+
+  IF p_deadline_type = 'submission' THEN
+    UPDATE public.rounds
+       SET submission_deadline_at = v_new_deadline
+     WHERE id = p_round_id;
+  ELSE
+    UPDATE public.rounds
+       SET voting_deadline_at = v_new_deadline
+     WHERE id = p_round_id;
+  END IF;
+
+  INSERT INTO public.deadline_extension_log (
+    round_id,
+    deadline_type,
+    outcome,
+    previous_deadline,
+    new_deadline,
+    extension_hours,
+    extension_minutes,
+    triggered_by,
+    triggered_by_user_id,
+    requested_count,
+    threshold_count,
+    capped_by_round_id,
+    reason
+  ) VALUES (
+    p_round_id,
+    p_deadline_type,
+    'extended',
+    v_previous_deadline,
+    v_new_deadline,
+    CEIL(v_duration_minutes / 60.0)::int,
+    v_duration_minutes,
+    p_triggered_by,
+    p_triggered_by_user_id,
+    v_requested_count,
+    v_threshold_count,
+    NULL,
+    v_reason
+  );
+
+  DELETE FROM public.deadline_extension_requests
+   WHERE round_id = p_round_id
+     AND deadline_type = p_deadline_type;
+
+  INSERT INTO public.notifications (user_id, type, title, body, data)
+  SELECT lm.user_id,
+         CASE WHEN p_deadline_type = 'submission' THEN 'subs_extended' ELSE 'voting_extended' END,
+         'Deadline extended',
+         CASE
+           WHEN p_deadline_type = 'submission' THEN 'The submission deadline was extended.'
+           ELSE 'The voting deadline was extended.'
+         END,
+         jsonb_build_object(
+           'round_id', p_round_id,
+           'season_id', v_season_id,
+           'league_id', v_league_id,
+           'deadline_type', p_deadline_type,
+           'previous_deadline', v_previous_deadline,
+           'new_deadline', v_new_deadline,
+           'capped', false
+         )
+    FROM public.league_members lm
+   WHERE lm.league_id = v_league_id;
+
+  RETURN jsonb_build_object(
+    'outcome', 'extended',
+    'previous_deadline', v_previous_deadline,
+    'new_deadline', v_new_deadline,
+    'requested_count', v_requested_count,
+    'threshold_count', v_threshold_count,
+    'capped', false
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.request_deadline_extension(
+  p_round_id uuid,
+  p_deadline_type text,
+  p_user_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_league_id uuid;
+  v_admin_user_id uuid;
+  v_inserted boolean := false;
+  v_result jsonb;
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Cannot request an extension for another user';
+  END IF;
+
+  SELECT s.league_id, l.admin_user_id
+    INTO v_league_id, v_admin_user_id
+    FROM public.rounds r
+    JOIN public.seasons s ON s.id = r.season_id
+    JOIN public.leagues l ON l.id = s.league_id
+   WHERE r.id = p_round_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Round not found';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.league_members lm
+     WHERE lm.league_id = v_league_id
+       AND lm.user_id = p_user_id
+       AND lm.role = 'participant'
+  ) THEN
+    RAISE EXCEPTION 'Only participants can request deadline extensions';
+  END IF;
+
+  INSERT INTO public.deadline_extension_requests (round_id, deadline_type, user_id)
+  VALUES (p_round_id, p_deadline_type, p_user_id)
+  ON CONFLICT (round_id, deadline_type, user_id) DO NOTHING
+  RETURNING true INTO v_inserted;
+
+  IF COALESCE(v_inserted, false) THEN
+    INSERT INTO public.notifications (user_id, type, title, body, data)
+    VALUES (
+      v_admin_user_id,
+      'deadline_extension_requested',
+      'Extension requested',
+      'A player requested a deadline extension.',
+      jsonb_build_object(
+        'round_id', p_round_id,
+        'league_id', v_league_id,
+        'deadline_type', p_deadline_type,
+        'requester_user_id', p_user_id
+      )
+    );
+  END IF;
+
+  v_result := public._apply_deadline_extension(
+    p_round_id,
+    p_deadline_type,
+    'vote_threshold',
+    p_user_id,
+    false
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.cancel_deadline_extension_request(
+  p_round_id uuid,
+  p_deadline_type text,
+  p_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_league_id uuid;
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Cannot cancel an extension request for another user';
+  END IF;
+
+  SELECT s.league_id
+    INTO v_league_id
+    FROM public.rounds r
+    JOIN public.seasons s ON s.id = r.season_id
+   WHERE r.id = p_round_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Round not found';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.league_members lm
+     WHERE lm.league_id = v_league_id
+       AND lm.user_id = p_user_id
+       AND lm.role = 'participant'
+  ) THEN
+    RAISE EXCEPTION 'Only participants can cancel deadline extension requests';
+  END IF;
+
+  DELETE FROM public.deadline_extension_requests
+   WHERE round_id = p_round_id
+     AND deadline_type = p_deadline_type
+     AND user_id = p_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.commissioner_extend_deadline(
+  p_round_id uuid,
+  p_deadline_type text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_admin_user_id uuid;
+BEGIN
+  SELECT l.admin_user_id
+    INTO v_admin_user_id
+    FROM public.rounds r
+    JOIN public.seasons s ON s.id = r.season_id
+    JOIN public.leagues l ON l.id = s.league_id
+   WHERE r.id = p_round_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Round not found';
+  END IF;
+
+  IF v_admin_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Only the commissioner can force a deadline extension';
+  END IF;
+
+  RETURN public._apply_deadline_extension(
+    p_round_id,
+    p_deadline_type,
+    'commissioner',
+    auth.uid(),
+    true
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.request_deadline_extension(uuid, text, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.cancel_deadline_extension_request(uuid, text, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.commissioner_extend_deadline(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._apply_deadline_extension(uuid, text, text, uuid, boolean) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._apply_deadline_extension(uuid, text, text, uuid, boolean) FROM authenticated;
+REVOKE ALL ON FUNCTION public._apply_deadline_extension(uuid, text, text, uuid, boolean) FROM anon;
+
+GRANT EXECUTE ON FUNCTION public.request_deadline_extension(uuid, text, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_deadline_extension_request(uuid, text, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.commissioner_extend_deadline(uuid, text) TO authenticated;


### PR DESCRIPTION
## Summary
- add deadline extension voting schema/RPCs with 33% rounded-up threshold, 24h extension duration, unlimited request rounds, and no-cascade boundary enforcement
- add mobile deadline-extension services, query hooks, and invalidation so request/cancel transitions do not flicker back to stale state
- update submission and voting UI for player extension requests, including the Apple Music-style voting controls and due-copy formatting
- add season creation defaults/config for extension requests and globally disable font scaling in the app

## Follow-up
- Created #59 to revisit extension UX inside the vote screen; current clock/action-sheet flow works but is not as polished as the submission-screen card.

## Validation
- `pnpm --filter @mix/mobile type-check`
- `git diff --check`

## Notes
- `pnpm-lock.yaml` had a pre-existing unstaged change and was intentionally excluded from this PR.
- Supabase local lint was not run here because the local Supabase DB is not running in this workspace.

Closes #24
