### PR TITLE
Add pull-to-refresh to profile and home

### DIFF
--- a/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
@@ -373,6 +373,7 @@ function HomeTabContent({
               refreshing={refreshing}
               onRefresh={onRefresh}
               tintColor={THEME.ink}
+              progressViewOffset={insets.top + headerHeight}
             />
           }
         >

--- a/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  RefreshControl,
+  ScrollView,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { usePlayback, usePlaybackPosition } from '@/playback/PlaybackContext';
 import { useSession } from '@/context/SessionContext';
@@ -152,7 +159,20 @@ export function ProfileTabScreen() {
   } = usePlayback();
   const { session, supabaseUserId, signOut } = useSession();
   const { setActiveLeagueId, activeLeagueId } = useLeague();
-  const { data: leagues = [] } = useMyLeagues(supabaseUserId ?? undefined);
+  const {
+    data: leagues = [],
+    refetch: refetchLeagues,
+  } = useMyLeagues(supabaseUserId ?? undefined);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refetchLeagues();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refetchLeagues]);
 
   const hasTrack = currentIndex !== null;
   const hasPrevious = currentIndex !== null && currentIndex > 0;
@@ -172,6 +192,13 @@ export function ProfileTabScreen() {
       style={{ backgroundColor: '#000' }}
       contentContainerStyle={[styles.root, { paddingTop: insets.top + 16 }]}
       showsVerticalScrollIndicator={false}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor="#fff"
+        />
+      }
     >
       {/* ── User profile ── */}
       <View style={styles.profileSection}>


### PR DESCRIPTION
Adds native pull-to-refresh to the Profile tab and positions Home’s native refresh loader below its fixed header so it remains visible while pulling.