### PR TITLE
Handle Spotify token revocation with graceful re-auth flow

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Stack, useRouter, useSegments } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter, useSegments } from "expo-router";
 import "@/lib/disableFontScaling";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -43,14 +43,18 @@ import { getValidAccessToken } from "@/lib/spotifyAuth";
 const PREVIEW_DEFAULT: string | null = null;
 
 function AuthGate({ children }: { children: React.ReactNode }) {
-  const { session, loading } = useSession();
+  const { session, loading, needsSpotifyReauth } = useSession();
   const { init } = useSpotifyPlayer();
   const segments = useSegments();
+  const params = useLocalSearchParams<{ reason?: string }>();
   const router = useRouter();
 
   // SessionProvider calls `refresh()` on every AppState foreground → new `session` object reference
   // even for the same user. Depending on `session` would re-run `init` → `mixInit` and kill Web Playback.
-  const spotifyUserId = session?.id ?? null;
+  const spotifyUserId =
+    session?.musicService === "spotify" && !needsSpotifyReauth
+      ? session.id
+      : null;
   useEffect(() => {
     if (!spotifyUserId) return;
     void getValidAccessToken().then((token) => {
@@ -64,6 +68,16 @@ function AuthGate({ children }: { children: React.ReactNode }) {
     const inAuthCallback = segments[0] === "auth";
     const inPreview = segments[0] === "ui-preview";
 
+    if (needsSpotifyReauth) {
+      if (params.reason !== "spotify-session-revoked") {
+        router.replace({
+          pathname: "/(auth)",
+          params: { reason: "spotify-session-revoked" },
+        });
+      }
+      return;
+    }
+
     // TEMP: while PREVIEW_DEFAULT is set, route all traffic into the preview.
     // TODO: remove this once the MVP tasks are completed and ready for production
     if (PREVIEW_DEFAULT && !inPreview && !inAuthCallback) {
@@ -76,7 +90,7 @@ function AuthGate({ children }: { children: React.ReactNode }) {
     } else if (session && inAuthGroup) {
       router.replace("/(tabs)/(home)");
     }
-  }, [session, loading, segments, router]);
+  }, [session, loading, needsSpotifyReauth, params.reason, segments, router]);
 
   return <>{children}</>;
 }

--- a/apps/mobile/src/context/SessionContext.tsx
+++ b/apps/mobile/src/context/SessionContext.tsx
@@ -24,6 +24,8 @@ interface SessionContextValue {
   session: MusicUserProfile | null;
   supabaseUserId: string | null;
   loading: boolean;
+  needsSpotifyReauth: boolean;
+  requireSpotifyReauth: () => void;
   signOut: () => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -32,6 +34,8 @@ const SessionContext = createContext<SessionContextValue>({
   session: null,
   supabaseUserId: null,
   loading: true,
+  needsSpotifyReauth: false,
+  requireSpotifyReauth: () => {},
   signOut: async () => {},
   refresh: async () => {},
 });
@@ -40,11 +44,23 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [profile, setProfile] = useState<MusicUserProfile | null>(null);
   const [supabaseUserId, setSupabaseUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [needsSpotifyReauth, setNeedsSpotifyReauth] = useState(false);
+  const needsSpotifyReauthRef = useRef(false);
   const appState = useRef(AppState.currentState);
+
+  const updateSpotifyReauth = useCallback((needed: boolean) => {
+    needsSpotifyReauthRef.current = needed;
+    setNeedsSpotifyReauth(needed);
+  }, []);
+
+  const requireSpotifyReauth = useCallback(() => {
+    updateSpotifyReauth(true);
+  }, [updateSpotifyReauth]);
 
   const refresh = useCallback(async () => {
     let p: MusicUserProfile | null = null;
     let selectedBy: 'spotify' | 'applemusic' | 'supabase-fallback' | null = null;
+    let spotifyReauthRequired = false;
 
     // ── Spotify path ───────────────────────────────────────────────────────────
     const spotifyProfile = await getSpotifyProfile();
@@ -62,31 +78,38 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
       });
     }
     if (spotifyProfile) {
+      const token = await getValidAccessToken();
+      if (!token) {
+        spotifyReauthRequired = true;
+        updateSpotifyReauth(true);
+      }
+
       // Crash recovery: if Spotify session exists but Supabase session was lost
       // (e.g. AsyncStorage cleared), re-run the auth bridge silently.
-      if (!(await hasSupabaseSession())) {
-        const token = await getValidAccessToken();
-        if (token) {
-          try {
-            await signInToSupabase(token);
-          } catch {
-            // Non-fatal — app still works for playback, DB calls will fail gracefully
-          }
+      if (token && !(await hasSupabaseSession())) {
+        try {
+          await signInToSupabase(token);
+        } catch {
+          // Non-fatal — app still works for playback, DB calls will fail gracefully
         }
       }
-      p = {
-        musicService: 'spotify',
-        id: spotifyProfile.id,
-        displayName: spotifyProfile.displayName,
-        email: spotifyProfile.email,
-        imageUrl: spotifyProfile.imageUrl,
-      };
-      selectedBy = 'spotify';
+      if (token) {
+        updateSpotifyReauth(false);
+        p = {
+          musicService: 'spotify',
+          id: spotifyProfile.id,
+          displayName: spotifyProfile.displayName,
+          email: spotifyProfile.email,
+          imageUrl: spotifyProfile.imageUrl,
+        };
+        selectedBy = 'spotify';
+      }
     }
 
     // ── Apple Music path ───────────────────────────────────────────────────────
-    if (!p) {
+    if (!p && !spotifyReauthRequired) {
       if (appleProfile) {
+        updateSpotifyReauth(false);
         p = {
           musicService: 'applemusic',
           id: appleProfile.id,
@@ -101,7 +124,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     // ── Fallback for email/password test players ───────────────────────────────
     // If neither music service has a local session but Supabase is still active,
     // build a minimal profile so the app recognises the user as signed in.
-    if (!p) {
+    if (!p && !spotifyReauthRequired && !needsSpotifyReauthRef.current) {
       const { data: sessionData } = await supabase.auth.getSession();
       const supabaseUser = sessionData.session?.user;
       if (supabaseUser) {
@@ -137,7 +160,7 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
       });
     }
     setLoading(false);
-  }, []);
+  }, [updateSpotifyReauth]);
 
   useEffect(() => {
     refresh();
@@ -159,11 +182,22 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     ]);
     setProfile(null);
     setSupabaseUserId(null);
+    updateSpotifyReauth(false);
     auditMusicCredentials('session.signOut.clearAllProviders.complete');
   };
 
   return (
-    <SessionContext.Provider value={{ session: profile, supabaseUserId, loading, signOut, refresh }}>
+    <SessionContext.Provider
+      value={{
+        session: profile,
+        supabaseUserId,
+        loading,
+        needsSpotifyReauth,
+        requireSpotifyReauth,
+        signOut,
+        refresh,
+      }}
+    >
       {children}
     </SessionContext.Provider>
   );

--- a/apps/mobile/src/lib/spotifyAuth.ts
+++ b/apps/mobile/src/lib/spotifyAuth.ts
@@ -1,7 +1,7 @@
 import * as Crypto from 'expo-crypto';
 import * as SecureStore from 'expo-secure-store';
 import * as WebBrowser from 'expo-web-browser';
-import { auditMusicCredentials } from './musicCredentialAudit';
+import { auditMusicCredentials, auditMusicCredentialWarning } from './musicCredentialAudit';
 
 const SPOTIFY_CLIENT_ID = process.env.EXPO_PUBLIC_SPOTIFY_CLIENT_ID!;
 const REDIRECT_URI = 'mix://auth/callback';
@@ -29,7 +29,23 @@ export interface SpotifyProfile {
   displayName: string;
   email?: string;
   imageUrl?: string;
+  // 'premium' is required for Web Playback SDK streaming. Captured at login
+  // and refreshable via refreshSpotifyProfile().
+  product?: string;
+  productCheckedAt?: number;
 }
+
+export class SpotifyRefreshRevokedError extends Error {
+  constructor(
+    public readonly errorDescription: string,
+    public readonly errorCode: string,
+  ) {
+    super(errorDescription || 'Spotify refresh token revoked');
+    this.name = 'SpotifyRefreshRevokedError';
+  }
+}
+
+let hasAuditedSpotifyRevocation = false;
 
 // ─── PKCE helpers ────────────────────────────────────────────────────────────
 
@@ -119,6 +135,7 @@ export async function loginWithSpotify(): Promise<SpotifyProfile> {
     provider: "spotify",
     spotifyUserId: profile.id,
     hasEmail: !!profile.email,
+    product: profile.product ?? "unknown",
     appleMusicCredentialsUsed: false,
   });
   return profile;
@@ -128,6 +145,7 @@ export async function loginWithSpotify(): Promise<SpotifyProfile> {
 
 export async function saveSpotifyTokens(tokens: SpotifyTokens) {
   await SecureStore.setItemAsync('spotify_tokens', JSON.stringify(tokens));
+  hasAuditedSpotifyRevocation = false;
   auditMusicCredentials("spotify.tokens.stored", {
     provider: "spotify",
     hasAccessToken: !!tokens.accessToken,
@@ -152,8 +170,24 @@ export async function refreshSpotifyTokens(refreshToken: string): Promise<Spotif
     }).toString(),
   });
   if (!res.ok) {
-    const err = await res.json() as { error_description?: string };
-    throw new Error(err.error_description ?? 'Token refresh failed');
+    const err = await res.json() as { error?: string; error_description?: string };
+    const errorCode = err.error ?? '';
+    const errorDescription = err.error_description ?? 'Token refresh failed';
+    const isRevoked = errorCode === 'invalid_grant';
+
+    if (isRevoked) {
+      if (!hasAuditedSpotifyRevocation) {
+        hasAuditedSpotifyRevocation = true;
+        auditMusicCredentialWarning('spotify.session.revoked', {
+          errorDescription,
+          errorCode,
+        });
+        await clearSpotifySession();
+      }
+      throw new SpotifyRefreshRevokedError(errorDescription, errorCode);
+    }
+
+    throw new Error(errorDescription);
   }
   const data = await res.json() as { access_token: string; refresh_token?: string; expires_in: number };
   const tokens: SpotifyTokens = {
@@ -181,8 +215,13 @@ export async function getValidAccessToken(): Promise<string | null> {
       provider: "spotify",
       result: "refreshing",
     });
-    const refreshed = await refreshSpotifyTokens(tokens.refreshToken);
-    return refreshed.accessToken;
+    try {
+      const refreshed = await refreshSpotifyTokens(tokens.refreshToken);
+      return refreshed.accessToken;
+    } catch (error) {
+      if (error instanceof SpotifyRefreshRevokedError) return null;
+      throw error;
+    }
   }
   auditMusicCredentials("spotify.token.requested", {
     provider: "spotify",
@@ -205,8 +244,13 @@ export async function forceRefreshAccessToken(): Promise<string | null> {
     provider: "spotify",
     result: "refreshing",
   });
-  const refreshed = await refreshSpotifyTokens(tokens.refreshToken);
-  return refreshed.accessToken;
+  try {
+    const refreshed = await refreshSpotifyTokens(tokens.refreshToken);
+    return refreshed.accessToken;
+  } catch (error) {
+    if (error instanceof SpotifyRefreshRevokedError) return null;
+    throw error;
+  }
 }
 
 export async function getSpotifyProfile(): Promise<SpotifyProfile | null> {
@@ -228,11 +272,50 @@ async function fetchSpotifyProfile(accessToken: string): Promise<SpotifyProfile>
     headers: { Authorization: `Bearer ${accessToken}` },
   });
   if (!res.ok) throw new Error('Failed to fetch Spotify profile');
-  const data = await res.json() as { id: string; display_name?: string; email?: string; images?: { url: string }[] };
+  const data = await res.json() as {
+    id: string;
+    display_name?: string;
+    email?: string;
+    images?: { url: string }[];
+    product?: string;
+  };
   return {
     id: data.id,
     displayName: data.display_name ?? data.id,
     email: data.email,
     imageUrl: data.images?.[0]?.url,
+    product: data.product,
+    productCheckedAt: Date.now(),
   };
+}
+
+// Re-fetches /v1/me with the current token and updates the stored profile.
+// Use this to check whether the account is still Premium without forcing the
+// user to log out. Returns the updated profile, or null if no session.
+export async function refreshSpotifyProfile(): Promise<SpotifyProfile | null> {
+  const token = await getValidAccessToken();
+  if (!token) return null;
+  try {
+    const profile = await fetchSpotifyProfile(token);
+    await SecureStore.setItemAsync('spotify_user', JSON.stringify(profile));
+    auditMusicCredentials("spotify.profile.refreshed", {
+      provider: "spotify",
+      spotifyUserId: profile.id,
+      product: profile.product ?? "unknown",
+      hasEmail: !!profile.email,
+    });
+    return profile;
+  } catch (err) {
+    auditMusicCredentialWarning("spotify.profile.refreshFailed", {
+      provider: "spotify",
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// Cheap read of the last-known token expiry for diagnostics.
+export async function getSpotifyTokenExpiry(): Promise<number | null> {
+  const tokens = await getSpotifyTokens();
+  return tokens?.expiresAt ?? null;
 }

--- a/apps/mobile/src/playback/SpotifyWebPlayer.tsx
+++ b/apps/mobile/src/playback/SpotifyWebPlayer.tsx
@@ -10,10 +10,17 @@ import { AppState, StyleSheet, View } from "react-native";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import {
   forceRefreshAccessToken,
+  getSpotifyProfile,
+  getSpotifyTokenExpiry,
   getValidAccessToken,
+  refreshSpotifyProfile,
 } from "@/lib/spotifyAuth";
 import { normalizeSpotifyTrackUri } from "@/lib/spotifyTrackUri";
-import { auditMusicCredentials } from "@/lib/musicCredentialAudit";
+import {
+  auditMusicCredentials,
+  auditMusicCredentialWarning,
+} from "@/lib/musicCredentialAudit";
+import { useSession } from "@/context/SessionContext";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -142,9 +149,10 @@ const PLAYER_HTML = `
       });
     });
 
-    player.addListener('initialization_error', function(e) { rn({ type: 'error', message: 'Init: ' + e.message }); });
+    player.addListener('initialization_error', function(e) { rn({ type: 'initialization_error', message: e.message }); });
     player.addListener('authentication_error', function(e) { rn({ type: 'authentication_error', message: e.message }); });
-    player.addListener('account_error', function(e) { rn({ type: 'error', message: 'Account: ' + e.message }); });
+    player.addListener('account_error', function(e) { rn({ type: 'account_error', message: e.message }); });
+    player.addListener('playback_error', function(e) { rn({ type: 'playback_error', message: e.message }); });
 
     player.connect().then(function(ok) {
       if (!ok) rn({ type: 'error', message: 'Failed to connect player' });
@@ -244,6 +252,7 @@ const HiddenWebView = ({
 // ─── Provider ─────────────────────────────────────────────────────────────────
 
 export function SpotifyPlayerProvider({ children }: { children: React.ReactNode }) {
+  const { requireSpotifyReauth } = useSession();
   const webViewRef = useRef<WebView>(null);
   const [remountKey, setRemountKey] = useState(0);
   const [isReady, setIsReady] = useState(false);
@@ -263,6 +272,10 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
   const expectedUriRef = useRef<string | null>(null);
 
   const externalTakeoverListenersRef = useRef(new Set<() => void>());
+
+  const lastStateRef = useRef<SpotifyTrackState | null>(null);
+  const lastPauseCommandAtRef = useRef<number>(0);
+  const playStartedAtRef = useRef<number>(0);
 
   const subscribeExternalTakeover = useCallback((listener: () => void) => {
     const set = externalTakeoverListenersRef.current;
@@ -306,15 +319,31 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
           if (listed) {
             deviceIdRef.current = capturedDeviceId;
             setIsReady(true);
+            void refreshSpotifyProfile();
           } else {
+            auditMusicCredentialWarning("playback.spotify.deviceNotListed", {
+              provider: "spotify",
+              reason: "device-never-listed-in-connect",
+            });
             console.warn("[SpotifyWebPlayer] device never appeared in Connect");
           }
         })();
 
       } else if (msg.type === "not_ready") {
+        auditMusicCredentialWarning("playback.spotify.deviceNotReady", {
+          provider: "spotify",
+          hadTrackState: !!lastStateRef.current,
+          lastPositionMs: lastStateRef.current?.positionMs,
+          lastDurationMs: lastStateRef.current?.durationMs,
+          msSincePlayStarted:
+            playStartedAtRef.current > 0
+              ? Date.now() - playStartedAtRef.current
+              : null,
+        });
         deviceIdRef.current = null;
         setIsReady(false);
         setTrackState(null);
+        lastStateRef.current = null;
 
       } else if (msg.type === "stateChanged") {
         if (suppressRef.current) return;
@@ -342,9 +371,40 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
           return;
         }
 
+        const prev = lastStateRef.current;
+        const justPaused = prev && !prev.isPaused && s.isPaused;
+        const sinceExplicitPause = Date.now() - lastPauseCommandAtRef.current;
+        const nearEnd =
+          s.durationMs > 0 && s.positionMs >= s.durationMs - 3000;
+        if (justPaused && sinceExplicitPause > 2000 && !nearEnd) {
+          auditMusicCredentialWarning("playback.spotify.spontaneousPause", {
+            provider: "spotify",
+            positionMs: s.positionMs,
+            durationMs: s.durationMs,
+            msSincePlayStarted:
+              playStartedAtRef.current > 0
+                ? Date.now() - playStartedAtRef.current
+                : null,
+            trackUri: s.trackUri,
+            likelyCause:
+              s.positionMs === 0
+                ? "sdk-rejected-track-check-premium-or-market"
+                : "session-preempted-or-license-expired",
+          });
+        }
+
+        lastStateRef.current = s;
         setTrackState(s);
 
       } else if (msg.type === "authentication_error") {
+        auditMusicCredentialWarning("playback.spotify.sdk.authenticationError", {
+          provider: "spotify",
+          message: (msg.message as string) ?? "",
+          msSincePlayStarted:
+            playStartedAtRef.current > 0
+              ? Date.now() - playStartedAtRef.current
+              : null,
+        });
         console.warn("[SpotifyWebPlayer] auth error:", msg.message);
         setIsReady(false);
         deviceIdRef.current = null;
@@ -355,16 +415,49 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
           if (t) {
             pendingTokenRef.current = t;
             inject(`window.mixInit(${JSON.stringify(t)})`);
+          } else {
+            requireSpotifyReauth();
           }
         })();
 
+      } else if (msg.type === "account_error") {
+        auditMusicCredentialWarning("playback.spotify.sdk.accountError", {
+          provider: "spotify",
+          message: (msg.message as string) ?? "",
+          hint: "usually-means-non-premium-account",
+        });
+        console.warn("[SpotifyWebPlayer] account error:", msg.message);
+        void refreshSpotifyProfile();
+
+      } else if (msg.type === "initialization_error") {
+        auditMusicCredentialWarning("playback.spotify.sdk.initializationError", {
+          provider: "spotify",
+          message: (msg.message as string) ?? "",
+        });
+        console.warn("[SpotifyWebPlayer] init error:", msg.message);
+
+      } else if (msg.type === "playback_error") {
+        auditMusicCredentialWarning("playback.spotify.sdk.playbackError", {
+          provider: "spotify",
+          message: (msg.message as string) ?? "",
+          msSincePlayStarted:
+            playStartedAtRef.current > 0
+              ? Date.now() - playStartedAtRef.current
+              : null,
+        });
+        console.warn("[SpotifyWebPlayer] playback error:", msg.message);
+
       } else if (msg.type === "error") {
+        auditMusicCredentialWarning("playback.spotify.sdk.error", {
+          provider: "spotify",
+          message: (msg.message as string) ?? "",
+        });
         console.warn("[SpotifyWebPlayer] error:", msg.message);
       } else if (msg.type === "log") {
         console.log("[SpotifyWebPlayer]", msg.message);
       }
     } catch {}
-  }, [inject, resetGate, emitExternalTakeover]);
+  }, [inject, resetGate, emitExternalTakeover, requireSpotifyReauth]);
 
   // ── WebView lifecycle ──────────────────────────────────────────────────────
 
@@ -396,25 +489,54 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
   const init = useCallback((token: string) => {
     pendingTokenRef.current = token;
     if (webViewLoadedRef.current) {
+      // mixInit rebuilds the SDK player, which re-registers the Connect
+      // device under whatever account owns this token. The old device id is
+      // account-scoped, so drop it now — play() polls until the new `ready`
+      // flow repopulates it.
+      readyGenRef.current += 1;
+      deviceIdRef.current = null;
+      setIsReady(false);
+      resetGate();
+      setTrackState(null);
       inject(`window.mixInit(${JSON.stringify(token)})`);
     }
-  }, [inject]);
+  }, [inject, resetGate]);
 
   const abandonMixSpotifySession = useCallback(() => {
     resetGate();
     setTrackState(null);
+    lastPauseCommandAtRef.current = Date.now();
     inject("window.mixPause()");
   }, [inject, resetGate]);
 
   const play = useCallback(async (uri: string) => {
     const trackUri = normalizeSpotifyTrackUri(uri);
+    const [profileSnapshot, expiresAtSnapshot] = await Promise.all([
+      getSpotifyProfile(),
+      getSpotifyTokenExpiry(),
+    ]);
     auditMusicCredentials("playback.spotify.play.requested", {
       provider: "spotify",
       requestedUri: uri,
       normalizedUri: trackUri,
       credentialSource: "spotify-user-token",
       appleMusicCredentialsUsed: false,
+      product: profileSnapshot?.product ?? "unknown",
+      productCheckedAgeMs: profileSnapshot?.productCheckedAt
+        ? Date.now() - profileSnapshot.productCheckedAt
+        : null,
+      msUntilTokenExpiry: expiresAtSnapshot
+        ? expiresAtSnapshot - Date.now()
+        : null,
+      spotifyUserId: profileSnapshot?.id,
     });
+    if (profileSnapshot?.product && profileSnapshot.product !== "premium") {
+      auditMusicCredentialWarning("playback.spotify.play.nonPremiumAccount", {
+        provider: "spotify",
+        product: profileSnapshot.product,
+        hint: "Web Playback SDK streams only for Premium",
+      });
+    }
     if (!/^spotify:track:[0-9A-Za-z]{22}$/.test(trackUri)) {
       console.warn("[SpotifyWebPlayer] invalid track uri:", uri, "→", trackUri);
       return;
@@ -433,6 +555,7 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
           appleMusicCredentialsUsed: false,
         });
         console.warn("[SpotifyWebPlayer] play: no valid token");
+        requireSpotifyReauth();
         resetGate();
         return;
       }
@@ -475,11 +598,27 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
 
       let res = await doPlay(freshToken, deviceId);
 
-      // 404 = device not ready yet; wait and retry once
+      // 404 = the device id isn't registered under this account — either
+      // stale after an account switch or dropped from Connect. Re-register
+      // the player and retry once with the fresh device id.
       if (res.status === 404) {
-        await new Promise((r) => setTimeout(r, 2_000));
+        auditMusicCredentialWarning("playback.spotify.play.deviceNotFound", {
+          provider: "spotify",
+          staleDeviceId: deviceId,
+        });
+        if (deviceIdRef.current === deviceId) deviceIdRef.current = null;
+        setIsReady(false);
         const retryToken = (await getValidAccessToken()) ?? freshToken;
-        res = await doPlay(retryToken, deviceId);
+        inject(`window.mixInit(${JSON.stringify(retryToken)})`);
+        let retryDeviceId: string | null = null;
+        const retryDeadline = Date.now() + 20_000;
+        while (Date.now() < retryDeadline) {
+          if (deviceIdRef.current) { retryDeviceId = deviceIdRef.current; break; }
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        if (retryDeviceId) {
+          res = await doPlay((await getValidAccessToken()) ?? retryToken, retryDeviceId);
+        }
       }
 
       if (!res.ok) {
@@ -498,12 +637,16 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
       // Success — open the gate
       acceptRef.current = true;
       suppressRef.current = false;
+      playStartedAtRef.current = Date.now();
+      lastStateRef.current = null;
       auditMusicCredentials("playback.spotify.play.started", {
         provider: "spotify",
         normalizedUri: trackUri,
         credentialSource: "spotify-user-token",
         appleMusicCredentialsUsed: false,
+        product: profileSnapshot?.product ?? "unknown",
       });
+
     } catch (e) {
       auditMusicCredentials("playback.spotify.play.failed", {
         reason: "exception",
@@ -513,9 +656,12 @@ export function SpotifyPlayerProvider({ children }: { children: React.ReactNode 
       console.warn("[SpotifyWebPlayer] play error:", e);
       resetGate();
     }
-  }, [inject, resetGate]);
+  }, [inject, requireSpotifyReauth, resetGate]);
 
-  const pause = useCallback(() => inject("window.mixPause()"), [inject]);
+  const pause = useCallback(() => {
+    lastPauseCommandAtRef.current = Date.now();
+    inject("window.mixPause()");
+  }, [inject]);
   const resume = useCallback(() => inject("window.mixResume()"), [inject]);
   const seek = useCallback(
     (positionMs: number) => inject(`window.mixSeek(${positionMs})`),

--- a/apps/mobile/src/screens/auth/AuthLoginScreen.tsx
+++ b/apps/mobile/src/screens/auth/AuthLoginScreen.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert, TextInput, Platform } from 'react-native';
 import * as WebBrowser from 'expo-web-browser';
+import { useLocalSearchParams } from 'expo-router';
 import { useSession } from '@/context/SessionContext';
 import { useAppleMusicPlayer } from '@/playback/AppleMusicPlayer';
 import { signInWithSpotify, signInWithPassword, signInWithAppleMusic } from '@/services/auth';
@@ -9,6 +10,7 @@ import { MixError } from '@/services/errors';
 WebBrowser.maybeCompleteAuthSession();
 
 export function AuthLoginScreen() {
+  const { reason } = useLocalSearchParams<{ reason?: string }>();
   const [loading, setLoading] = useState(false);
   const [devMode, setDevMode] = useState(false);
   const [email, setEmail] = useState('');
@@ -79,6 +81,12 @@ export function AuthLoginScreen() {
       <TouchableOpacity onPress={handleTitleTap} activeOpacity={1}>
         <Text style={styles.title}>mix</Text>
       </TouchableOpacity>
+
+      {reason === 'spotify-session-revoked' && (
+        <Text style={styles.reauthMessage}>
+          Your Spotify session expired. Sign in again to continue playing.
+        </Text>
+      )}
 
       <TouchableOpacity
         style={[styles.button, loading && styles.buttonBusy]}
@@ -153,6 +161,14 @@ const styles = StyleSheet.create({
     fontWeight: '900',
     color: '#fff',
     letterSpacing: -2,
+  },
+  reauthMessage: {
+    width: '100%',
+    maxWidth: 320,
+    color: '#fff',
+    fontSize: 16,
+    lineHeight: 22,
+    textAlign: 'center',
   },
   button: {
     width: '100%',


### PR DESCRIPTION
## Summary

- **Revocation detection**: `refreshSpotifyTokens` now recognises `invalid_grant` as a session revocation, clears stored tokens, emits an audit event, and throws a typed `SpotifyRefreshRevokedError` so callers don't conflate it with transient network failures
- **Re-auth gate**: `SessionContext` gains `needsSpotifyReauth` / `requireSpotifyReauth`; `_layout.tsx` routes the user back to the login screen with a `reason=spotify-session-revoked` param and shows a contextual message; param-guarded to prevent redirect loops
- **Player hardening**: player init is gated on a valid token; 404 from the Connect API now re-registers the device (inject `mixInit` → wait for `ready`) instead of retrying on a stale device id; `requireSpotifyReauth` called on auth failure when no fresh token is available
- **Diagnostics**: structured audit events for spontaneous pauses, account/init/playback/auth SDK errors; `product` (premium/free) captured on profile and logged at play time

## Test plan

- [ ] Simulate revocation: manually delete the refresh token from SecureStore while logged in → app should navigate to login with "Your Spotify session expired" message
- [ ] Normal login → play flow unaffected
- [ ] Background → foreground refresh cycle still works (token valid path)
- [ ] Non-premium account: verify `account_error` audit event fires and profile refresh is triggered
- [ ] 404 device-not-found retry: kill and restart the WebView mid-session, confirm play recovers without requiring manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)