### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,4 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "bash scripts/ensure-metro.sh && pnpm install"

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,0 @@
-{
-  "scripts": {
-    "setup": "bash scripts/ensure-metro.sh && pnpm install"
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.