### PR TITLE
Refine home round presentation

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "ios:sim": "expo run:ios",
-    "ios:device": "expo run:ios --device 00008150-001A310801F0401C",
+    "ios:device": "expo run:ios --device ${IOS_DEVICE_ID:-00008150-001A310801F0401C}",
     "vic": "expo run:ios --device 00008150-001A310801F0401C"
   },
   "dependencies": {

--- a/apps/mobile/src/app/ui-preview/index.tsx
+++ b/apps/mobile/src/app/ui-preview/index.tsx
@@ -209,9 +209,7 @@ export default function V1ArchiveHome() {
           />
 
           <HeroRoundCard
-            prompt={ACTIVE.prompt}
-            descriptor={ACTIVE.descriptor}
-            phaseLabel={ACTIVE.phase}
+            roundName={ACTIVE.prompt}
             ctaLabel={`${ACTIVE.submitted} picks in · tap to vote →`}
             status="live"
             imageKey={ACTIVE.imageKey}

--- a/apps/mobile/src/screens/round/RoundScreen.tsx
+++ b/apps/mobile/src/screens/round/RoundScreen.tsx
@@ -2470,7 +2470,6 @@ function SubmissionsHero({
         <FittedChromeTitle
           text={round.prompt.toUpperCase()}
           textStyle={styles.heroTitle}
-          minimumFontScale={0.5}
           maxStarSize={44}
         />
       </HaloText>

--- a/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
+++ b/apps/mobile/src/screens/tabs/HomeTabScreen.tsx
@@ -50,7 +50,7 @@ import { PlaylistRail } from '@/ui/cards/PlaylistRail';
 import { useTabBarBottomInset } from '@/ui/hooks/useTabBarBottomInset';
 import { THEME } from '@/ui/theme';
 
-import { derivePhase, formatPhaseCountdown } from '@/lib/utils/phase';
+import { derivePhase } from '@/lib/utils/phase';
 import { roundCoverKey } from '@/lib/utils/coverKey';
 
 const HOME_HERO_IMAGE_KEY = 'disco-balloon-hero';
@@ -98,7 +98,7 @@ function useZoomCooldown() {
 export function HomeTabScreen() {
   const router = useRouter();
   const { supabaseUserId } = useSession();
-  const { activeLeagueId, loading: leagueLoading } = useLeagueContext();
+  const { activeLeagueId, activeLeague, loading: leagueLoading } = useLeagueContext();
   const bottomInset = useTabBarBottomInset();
   const armAndPush = useZoomCooldown();
 
@@ -119,6 +119,7 @@ export function HomeTabScreen() {
   return (
     <HomeTabContent
       leagueId={activeLeagueId}
+      leagueName={activeLeague?.name}
       userId={supabaseUserId}
       router={router}
       bottomInset={bottomInset}
@@ -131,12 +132,14 @@ export function HomeTabScreen() {
 // actually an active league. Keeps hook count stable per render.
 function HomeTabContent({
   leagueId,
+  leagueName,
   userId,
   router,
   bottomInset,
   armAndPush,
 }: {
   leagueId: string;
+  leagueName?: string;
   userId: string | null;
   router: ReturnType<typeof useRouter>;
   bottomInset: number;
@@ -271,12 +274,8 @@ function HomeTabContent({
   const hero = useMemo(() => {
     if (!round) return null;
     const phase = derivePhase(round);
-    const phaseLabel = formatPhaseCountdown(round);
     const status = phaseToHeroStatus(phase);
     const submittedCount = submissions.length;
-    const descriptor = round.seasons?.name
-      ? `Round ${String(round.round_number).padStart(2, '0')} · ${round.seasons.name}`
-      : `Round ${String(round.round_number).padStart(2, '0')}`;
     const ctaLabel =
       phase === 'voting' || phase === 'submissions'
         ? `${submittedCount} picks in · tap to ${phase === 'voting' ? 'vote' : 'submit'} →`
@@ -286,8 +285,6 @@ function HomeTabContent({
     return {
       id: round.id,
       prompt: round.prompt,
-      descriptor,
-      phaseLabel,
       status,
       ctaLabel,
       imageKey: HOME_HERO_IMAGE_KEY,
@@ -380,9 +377,7 @@ function HomeTabContent({
           {hero ? (
             <>
               <HeroRoundCard
-                prompt={hero.prompt}
-                descriptor={hero.descriptor}
-                phaseLabel={hero.phaseLabel}
+                roundName={hero.prompt}
                 ctaLabel={hero.ctaLabel}
                 status={hero.status}
                 imageKey={hero.imageKey}
@@ -406,16 +401,13 @@ function HomeTabContent({
                   "dripping" into the headline. */}
               <View style={styles.tether} />
 
-              {/* Round title block — italic Fraunces headline + chrome ★, set
-                  against a dual-layer radial halo. Sits directly below the
-                  active card, matching the Bubblegum home spec. */}
+              {/* League title block — the active league anchors the home
+                  surface, while the round name stays on the active card. */}
               <View style={styles.roundTitleBlock}>
-                <Text style={styles.roundTitleTagline}>this sounds like</Text>
                 <HaloText style={styles.roundTitleHaloWrap}>
                   <FittedChromeTitle
-                    text={hero.prompt.toUpperCase()}
+                    text={(league?.name ?? leagueName ?? 'MIX').toUpperCase()}
                     textStyle={styles.roundTitleText}
-                    minimumFontScale={0.58}
                     maxStarSize={32}
                   />
                 </HaloText>
@@ -588,7 +580,7 @@ const styles = StyleSheet.create({
     color: THEME.ink,
   },
 
-  // Round title block below the active hero card.
+  // League title block below the active hero card.
   roundTitleBlock: {
     alignItems: 'center',
     marginTop: 8,
@@ -596,13 +588,6 @@ const styles = StyleSheet.create({
     gap: 4,
     paddingHorizontal: 22,
     overflow: 'visible',
-  },
-  roundTitleTagline: {
-    fontFamily: THEME.fonts.serifItalic,
-    fontSize: 17,
-    color: THEME.ink,
-    // Raise above HaloText's spill so the blur doesn't capture this label.
-    zIndex: 2,
   },
   roundTitleHaloWrap: {
     flexDirection: 'row',
@@ -615,9 +600,9 @@ const styles = StyleSheet.create({
   },
   roundTitleText: {
     fontFamily: THEME.fonts.serifBoldItalic,
-    fontSize: 52,
-    lineHeight: 56,
-    letterSpacing: -2.2,
+    fontSize: 48,
+    lineHeight: 52,
+    letterSpacing: -2,
     color: THEME.ink,
     textAlign: 'center',
   },

--- a/apps/mobile/src/ui/FittedChromeTitle.tsx
+++ b/apps/mobile/src/ui/FittedChromeTitle.tsx
@@ -8,96 +8,93 @@ import {
 } from "react-native";
 import { ChromeText } from "@/ui/ChromeText";
 
-// Walk a StyleProp and pull out the most-specific fontSize (later styles
-// win, mirroring RN's own style cascade). Used to size the optical-center
-// nudge for the chrome star inline with the title — scaling per-title-size
-// rather than per-star-size means submissions (74pt) and home (52pt) both
-// land on the optical midline of italic Fraunces caps.
-function extractFontSize(style: StyleProp<TextStyle>): number | undefined {
-  if (!style) return undefined;
-  if (Array.isArray(style)) {
-    for (let i = style.length - 1; i >= 0; i--) {
-      const fs = extractFontSize(style[i] as StyleProp<TextStyle>);
-      if (fs !== undefined) return fs;
-    }
-    return undefined;
-  }
-  const s = style as TextStyle;
-  return typeof s.fontSize === "number" ? s.fontSize : undefined;
-}
-
 export type FittedChromeTitleProps = {
   text: string;
   textStyle: StyleProp<TextStyle>;
   style?: StyleProp<ViewStyle>;
-  minimumFontScale?: number;
   maxStarSize: number;
   starGap?: number;
-  lineOverlap?: number;
 };
 
-function splitMidpoint(text: string): string[] {
-  const trimmed = text.trim();
-  const spaces = [...trimmed.matchAll(/\s+/g)];
-  if (spaces.length === 0) return [trimmed];
+const FULL_SIZE_LENGTH = 10;
+const WRAP_LENGTH = 15;
+const MINIMUM_SCALE = 0.72;
 
-  const midpoint = trimmed.length / 2;
-  const split = spaces.reduce((best, match) => {
-    const index = match.index ?? 0;
-    return Math.abs(index - midpoint) < Math.abs(best - midpoint)
-      ? index
-      : best;
-  }, spaces[0].index ?? 0);
+function wrapTitle(text: string): string[] {
+  const lines: string[] = [];
+  let line = "";
 
-  return [trimmed.slice(0, split), trimmed.slice(split).trim()].filter(Boolean);
+  for (const word of text.trim().split(/\s+/)) {
+    const chunks = Array.from(word.matchAll(new RegExp(`.{1,${WRAP_LENGTH}}`, "g")), (match) => match[0]);
+
+    for (const chunk of chunks) {
+      const candidate = line ? `${line} ${chunk}` : chunk;
+      if (candidate.length <= WRAP_LENGTH) {
+        line = candidate;
+      } else {
+        if (line) lines.push(line);
+        line = chunk;
+      }
+    }
+  }
+
+  if (line) lines.push(line);
+  return lines;
+}
+
+function fontScaleForLength(length: number): number {
+  if (length <= FULL_SIZE_LENGTH) return 1;
+  if (length >= WRAP_LENGTH) return MINIMUM_SCALE;
+
+  const progress = (length - FULL_SIZE_LENGTH) / (WRAP_LENGTH - FULL_SIZE_LENGTH);
+  return 1 - progress * (1 - MINIMUM_SCALE);
 }
 
 export function FittedChromeTitle({
   text,
   textStyle,
   style,
-  minimumFontScale = 0.5,
   maxStarSize,
   starGap = 6,
-  lineOverlap = -10,
 }: FittedChromeTitleProps) {
-  const lines = splitMidpoint(text);
-  const titleFontSize = extractFontSize(textStyle);
-  // Italic Fraunces caps sit visually below the geometric line-box center
-  // — the ascender + slant pull the bbox up further than the descender
-  // pulls it down. To land the chrome star on the optical midline of the
-  // caps, shift it down by ~12% of the *title's* fontSize (so 74pt title
-  // gets ~9pt, 52pt title gets ~6pt). Fall back to a star-size scale if
-  // the text style doesn't expose a fontSize.
-  const starMarginTop = titleFontSize
-    ? titleFontSize * 0.12
-    : maxStarSize * 0.18;
+  const lines = wrapTitle(text);
+  const flattenedTextStyle = StyleSheet.flatten(textStyle);
 
   return (
     <View style={[styles.root, style]}>
       {lines.map((line, index) => {
-        const hasAccent = index === lines.length - 1;
+        const isFinalLine = index === lines.length - 1;
+        // The final line shares horizontal space with the chrome star, so
+        // include it in the same character budget as the title text.
+        const effectiveLength = line.length + (isFinalLine ? 2 : 0);
+        const scale = fontScaleForLength(effectiveLength);
+        const scaledTextStyle: TextStyle = {
+          fontSize:
+            typeof flattenedTextStyle.fontSize === "number"
+              ? flattenedTextStyle.fontSize * scale
+              : undefined,
+          lineHeight:
+            typeof flattenedTextStyle.lineHeight === "number"
+              ? flattenedTextStyle.lineHeight * scale
+              : undefined,
+          letterSpacing:
+            typeof flattenedTextStyle.letterSpacing === "number"
+              ? flattenedTextStyle.letterSpacing * scale
+              : undefined,
+        };
         return (
-          <View
-            key={`${index}-${line}`}
-            style={[styles.line, index > 0 ? { marginTop: lineOverlap } : null]}
-          >
+          <View key={`${index}-${line}`} style={styles.line}>
             <Text
-              style={[textStyle, styles.lineText]}
+              style={[textStyle, styles.lineText, scaledTextStyle]}
               numberOfLines={1}
-              adjustsFontSizeToFit
-              minimumFontScale={minimumFontScale}
             >
               {line}
             </Text>
-            {hasAccent ? (
+            {isFinalLine ? (
               <ChromeText
                 glyph="★"
                 size={maxStarSize}
-                style={[
-                  styles.accent,
-                  { marginLeft: starGap, marginTop: starMarginTop },
-                ]}
+                style={[styles.accent, { marginLeft: starGap }]}
               />
             ) : null}
           </View>
@@ -114,18 +111,16 @@ const styles = StyleSheet.create({
     overflow: "visible",
   },
   line: {
+    width: "100%",
     maxWidth: "100%",
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     overflow: "visible",
-    paddingHorizontal: 8,
-    paddingVertical: 3,
   },
   lineText: {
     flexShrink: 1,
     minWidth: 0,
-    width: "100%",
   },
   accent: {
     flexShrink: 0,

--- a/apps/mobile/src/ui/cards/HeroRoundCard.tsx
+++ b/apps/mobile/src/ui/cards/HeroRoundCard.tsx
@@ -1,5 +1,5 @@
-// Big "Live round · vote open" editorial card with prompt, descriptor,
-// phase countdown, optional live dot badge, and CTA. The image fills
+// Big active-round editorial card with the round name, optional live dot
+// badge, and CTA. The image fills
 // a 16:10 tile with a top-anchored cover-fit crop matching the preview.
 
 import { Image } from "expo-image";
@@ -29,9 +29,7 @@ export type HeroStatus =
   | "results";
 
 export type HeroRoundCardProps = {
-  prompt: string;
-  descriptor?: string;
-  phaseLabel: string;
+  roundName: string;
   ctaLabel?: string;
   status?: HeroStatus;
   imageKey?: string;
@@ -56,9 +54,7 @@ function showsLiveDot(status: HeroStatus | undefined): boolean {
 }
 
 export function HeroRoundCard({
-  prompt,
-  descriptor,
-  phaseLabel,
+  roundName,
   ctaLabel,
   status = "live",
   imageKey,
@@ -82,13 +78,9 @@ export function HeroRoundCard({
     </View>
   ) : null;
 
-  // Caption + descriptor are no longer painted on the home page (the round
-  // prompt now renders below the card as its own halo'd headline). They
-  // remain in props for callers that still want them surfaced (e.g. the
-  // ui-preview playground); silence the lint warnings here.
+  // The live badge encodes the active state. Keep the richer status caption
+  // available for a future card variant without painting redundant copy.
   void caption;
-  void prompt;
-  void descriptor;
 
   return (
     <View style={style}>
@@ -108,7 +100,7 @@ export function HeroRoundCard({
             </View>
           ) : null}
           <View style={styles.imageFooter} pointerEvents="none">
-            <Text style={styles.phase}>{phaseLabel.toUpperCase()}</Text>
+            <Text style={styles.roundName}>{roundName.toUpperCase()}</Text>
             {ctaLabel ? <Text style={styles.cta}>{ctaLabel}</Text> : null}
           </View>
         </Pressable>
@@ -168,7 +160,7 @@ const styles = StyleSheet.create({
     right: 16,
     alignItems: "center",
   },
-  phase: {
+  roundName: {
     fontFamily: THEME.fonts.monoBold,
     fontSize: 10,
     letterSpacing: 1.6,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ios": "pnpm --filter @mix/mobile ios",
     "ios:sim": "pnpm --filter @mix/mobile ios:sim",
     "ios:device": "pnpm --filter @mix/mobile ios:device",
+    "doctor": "bash scripts/doctor-ios.sh",
     "vic": "pnpm --filter @mix/mobile vic",
     "setup": "pnpm install && pnpm --filter @mix/mobile prebuild"
   },

--- a/scripts/doctor-ios.sh
+++ b/scripts/doctor-ios.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Restore the local prerequisites for running the iOS app on a physical device.
+# This deliberately does not run `expo prebuild --clean`, which can overwrite
+# native-project changes. Set IOS_DEVICE_ID to target a different iPhone.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mobile_root="$repo_root/apps/mobile"
+ios_root="$mobile_root/ios"
+device_id="${IOS_DEVICE_ID:-00008150-001A310801F0401C}"
+
+fail() {
+  printf '\n✗ %s\n' "$1" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+echo "→ Checking local iOS tooling"
+require_command node
+require_command pnpm
+require_command xcodebuild
+require_command xcrun
+require_command pod
+xcodebuild -version | sed -n '1,2p'
+echo "CocoaPods $(pod --version)"
+
+echo "→ Restoring JavaScript dependencies"
+pnpm --dir "$repo_root" install --frozen-lockfile
+
+manifest_lock="$ios_root/Pods/Manifest.lock"
+pod_lock="$ios_root/Podfile.lock"
+workspace="$ios_root/mix.xcworkspace"
+
+if [[ ! -d "$workspace" || ! -f "$manifest_lock" || ! -s "$pod_lock" ]] \
+  || ! cmp -s "$pod_lock" "$manifest_lock"; then
+  echo "→ Installing CocoaPods dependencies"
+  (
+    cd "$ios_root"
+    pod install
+  )
+else
+  echo "✓ CocoaPods dependencies are current"
+fi
+
+echo "→ Checking iPhone connection ($device_id)"
+if ! xcrun xctrace list devices 2>&1 | grep -Fq "$device_id"; then
+  fail "The configured iPhone is not connected. Plug it in, unlock it, and trust this Mac. Set IOS_DEVICE_ID to use another device."
+fi
+
+set +e
+ddi_output="$(xcrun devicectl device info ddiServices --device "$device_id" --timeout 15 2>&1)"
+ddi_status=$?
+set -e
+
+if [[ $ddi_status -ne 0 ]]; then
+  if grep -Fq "kAMDMobileImageMounterDeviceLocked" <<<"$ddi_output"; then
+    fail "Your iPhone is locked, so Xcode cannot mount its developer image. Unlock it and keep it awake, then run pnpm run doctor again."
+  fi
+  echo "$ddi_output" >&2
+  fail "Xcode could not prepare the developer image. In Xcode, open Window > Devices and Simulators, unlock/trust the iPhone, then retry."
+fi
+
+echo "✓ iPhone developer services are ready"
+printf '\nReady to run: pnpm run ios:device\n'


### PR DESCRIPTION
## Summary
- Refine home round and league presentation with improved fitted title wrapping.
- Simplify the hero card to show the round name and add an iOS device doctor command.

## Validation
- `pnpm --filter @mix/mobile type-check` ✅
- `bash -n scripts/doctor-ios.sh` ✅
- `git diff --check` ✅
- Mobile lint is currently blocked by the repository’s ESLint 9 configuration mismatch (no `eslint.config.*`).